### PR TITLE
Automatically store access/refresh token in config

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -40,18 +40,35 @@
                 "default": "en"
             },
             "email": {
-                "title": "Email",
+                "title": "Airstage Email",
                 "type": "string",
-                "required": true,
+                "format": "email",
                 "default": "",
-                "description": "Airstage email"
+                "description": "This will be automatically removed after the initial authentication with the Airstage API, and an access token will be used instead."
             },
             "password": {
-                "title": "Password",
+                "title": "Airstage Password",
                 "type": "string",
-                "required": true,
                 "default": "",
-                "description": "Airstage password"
+                "description": "This will be automatically removed after the initial authentication with the Airstage API, and an access token will be used instead."
+            },
+            "accessToken": {
+                "title": "Airstage Access Token",
+                "type": "string",
+                "default": "",
+                "description": "This will be automatically be set after the initial authentication with the Airstage API."
+            },
+            "accessTokenExpiry": {
+                "title": "Airstage Access Token Expiry",
+                "type": "string",
+                "default": "",
+                "description": "This will be automatically be set after the initial authentication with the Airstage API."
+            },
+            "refreshToken": {
+                "title": "Airstage Refresh Token",
+                "type": "string",
+                "default": "",
+                "description": "This will be automatically be set after the initial authentication with the Airstage API."
             },
             "enableThermostat": {
                 "title": "Enable thermostat control",

--- a/src/airstage/apiv1/client.js
+++ b/src/airstage/apiv1/client.js
@@ -17,6 +17,10 @@ class Client {
         accessTokenExpiry = null,
         refreshToken = null
     ) {
+        if (typeof accessTokenExpiry === 'string') {
+            accessTokenExpiry = new Date(accessTokenExpiry);
+        }
+
         this.region = region;
         this.country = country;
         this.language = language;

--- a/src/airstage/apiv1/client.js
+++ b/src/airstage/apiv1/client.js
@@ -224,6 +224,11 @@ class Client {
 
         if (this.accessToken) {
             requestHeaders[constants.REQUEST_HEADER_AUTHORIZATION] = 'Bearer ' + this.accessToken;
+        } else {
+            const result = structuredClone(constants.REQUEST_RESULT);
+            result.error = 'Access token not set';
+
+            return callback(result);
         }
 
         requestOptions = {
@@ -247,6 +252,11 @@ class Client {
 
         if (this.accessToken) {
             requestHeaders[constants.REQUEST_HEADER_AUTHORIZATION] = 'Bearer ' + this.accessToken;
+        } else if (path !== constants.PATH_USERS_SIGN_IN) {
+            const result = structuredClone(constants.REQUEST_RESULT);
+            result.error = 'Access token not set';
+
+            return callback(result);
         }
 
         requestOptions = {

--- a/src/airstage/apiv1/constants.js
+++ b/src/airstage/apiv1/constants.js
@@ -84,6 +84,7 @@ module.exports.PARAMETER_RESULT_SUCCESS = 'success';
 module.exports.USER_TEMPERATURE_SCALE = 'tempUnit';
 
 // Message codes
+module.exports.MESSAGE_CODE_INVALID_LOGIN = 'AIRSTAGE_POST_USERS_SIGNIN_EMAIL_PASSWORD_INVALID';
 module.exports.MESSAGE_CODE_INVALID_TOKEN = 'AIRSTAGE_COMMON_TOKEN_INVALID';
 
 // Temperature scales

--- a/src/airstage/client.js
+++ b/src/airstage/client.js
@@ -35,6 +35,16 @@ class Client {
         this.resetDeviceCache(null);
     }
 
+    refreshTokenOrAuthenticate(callback) {
+        if (this._apiClient.accessToken && this._apiClient.refreshToken) {
+            this.refreshToken(callback);
+        } else if (this.email && this.password) {
+            this.authenticate(callback);
+        } else {
+            callback('Could not refresh token or authenticate', null);
+        }
+    }
+
     authenticate(callback) {
         this._apiClient.postUsersSignIn(
             this.email,
@@ -676,6 +686,18 @@ class Client {
                 delete this._deviceParameterCache[deviceId];
             }
         }
+    }
+
+    getAccessToken() {
+        return this._apiClient.accessToken;
+    }
+
+    getAccessTokenExpiry() {
+        return this._apiClient.accessTokenExpiry;
+    }
+
+    getRefreshToken() {
+        return this._apiClient.refreshToken;
     }
 
     _getDevices(

--- a/src/config-manager.js
+++ b/src/config-manager.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const fs = require('node:fs');
+
+class ConfigManager {
+
+    constructor(config, api) {
+        this.api = api;
+        this.config = config;
+    }
+
+    updateConfigWithAccessToken(accessToken, accessTokenExpiry, refreshToken) {
+        const homebridgeConfigPath = this.api.user.configPath();
+        const homebridgeConfigString = this._readFileSync(homebridgeConfigPath);
+        let homebridgeConfig = JSON.parse(homebridgeConfigString);
+
+        this.config.email = null;
+        this.config.password = null;
+
+        this.config.accessToken = accessToken;
+        this.config.accessTokenExpiry = accessTokenExpiry.toISOString();
+        this.config.refreshToken = refreshToken;
+
+        homebridgeConfig.platforms.some(function(platformConfig, idx, platforms) {
+            if (platformConfig.platform === this.config.platform) {
+                platforms[idx] = this.config;
+
+                return true;
+            }
+        }, this);
+
+        const updatedConfigString = JSON.stringify(homebridgeConfig, null, 4);
+
+        if (updatedConfigString !== homebridgeConfigString) {
+            this._writeFileSync(homebridgeConfigPath, updatedConfigString);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    _readFileSync(path) {
+        return fs.readFileSync(path).toString();
+    }
+
+    _writeFileSync(path, jsonString) {
+        return fs.writeFileSync(path, jsonString);
+    }
+}
+
+module.exports = ConfigManager;

--- a/src/platform.js
+++ b/src/platform.js
@@ -57,27 +57,21 @@ class Platform {
     }
 
     discoverDevices() {
-        this.airstageClient.authenticate((function(error) {
+        this.airstageClient.refreshTokenOrAuthenticate((function(error) {
             if (error) {
-                throw new this.api.hap.HapStatusError(
-                    this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
-                );
+                return this.log.error('Error when attempting to authenticate with Airbridge:', error);
             }
 
             this._updateConfigWithAccessToken();
 
             this.airstageClient.getUserMetadata((function(error) {
                 if (error) {
-                    throw new this.api.hap.HapStatusError(
-                        this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
-                    );
+                    return this.log.error('Error when attempting to communicate with Airbridge:', error);
                 }
 
                 this.airstageClient.getDevices(null, (function(error, result) {
                     if (error) {
-                        throw new this.api.hap.HapStatusError(
-                            this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
-                        );
+                        return this.log.error('Error when attempting to communicate with Airbridge:', error);
                     }
 
                     const deviceIds = Object.keys(result.metadata);

--- a/test/airstage/apiv1/test-client.js
+++ b/test/airstage/apiv1/test-client.js
@@ -11,7 +11,7 @@ const clientWithAccessToken = new airstage.apiv1.Client(
     null,
     null,
     'existingAccessToken',
-    new Date('2099-01-01'),
+    '2099-01-01',
     'existingRefreshToken'
 );
 
@@ -97,7 +97,7 @@ test('airstage.apiv1.Client#postUsersMeRefreshToken calls _makeHttpsRequest with
         null,
         null,
         'existingAccessToken',
-        new Date('2099-01-01'),
+        '2099-01-01',
         'existingRefreshToken'
     );
     const expectedResponse = {
@@ -143,7 +143,7 @@ test('airstage.apiv1.Client#postUsersMeRefreshToken calls _makeHttpsRequest with
         null,
         null,
         'existingAccessToken',
-        new Date('2099-01-01'),
+        '2099-01-01',
         'existingRefreshToken'
     );
     const expectedError = 'Error';

--- a/test/airstage/test-client.js
+++ b/test/airstage/test-client.js
@@ -136,11 +136,6 @@ test('airstage.Client#refreshTokenOrAuthenticate returns error', (context, done)
         'United States',
         'en'
     );
-    const expectedResponse = {
-        'accessToken': 'testAccessToken',
-        'expiresIn': 3600,
-        'refreshToken': 'testRefreshToken'
-    };
     context.mock.method(
         client._apiClient,
         'postUsersMeRefreshToken'

--- a/test/airstage/test-client.js
+++ b/test/airstage/test-client.js
@@ -13,7 +13,7 @@ let client = new airstage.Client(
     null,
     null,
     'existingAccessToken',
-    new Date('2099-01-01'),
+    '2099-01-01',
     'existingRefreshToken'
 );
 

--- a/test/test-config-manager.js
+++ b/test/test-config-manager.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mock, test } = require('node:test');
+const ConfigManager = require('../src/config-manager');
+
+const mockApi = {
+    'user': {
+        'configPath': mock.fn(() => {
+            return '/test/path';
+        })
+    }
+};
+
+test('ConfigManager#updateConfigWithAccessToken updates the config with new access token', (context) => {
+    let platformConfig = {
+        'email': 'test@example.com',
+        'password': 'test1234',
+        'accessToken': null,
+        'accessTokenExpiry': null,
+        'refreshToken': null
+    };
+    let homebridgeConfig = {
+        'platforms': [
+            platformConfig
+        ]
+    };
+    const accessToken = 'testAccessToken';
+    const accessTokenExpiry = new Date();
+    const refreshToken = 'testRefreshToken';
+    const configManager = new ConfigManager(platformConfig, mockApi);
+    context.mock.method(
+        configManager,
+        '_readFileSync',
+        (path) => {
+            return JSON.stringify(homebridgeConfig, null, 4);
+        }
+    );
+    context.mock.method(
+        configManager,
+        '_writeFileSync',
+        (path, jsonString) => {}
+    );
+
+    const result = configManager.updateConfigWithAccessToken(
+        accessToken,
+        accessTokenExpiry,
+        refreshToken
+    );
+
+    const expectedHomebridgeConfig = JSON.stringify(homebridgeConfig, null, 4);
+    assert.strictEqual(result, true);
+    assert.strictEqual(platformConfig.email, null);
+    assert.strictEqual(platformConfig.password, null);
+    assert.strictEqual(platformConfig.accessToken, accessToken);
+    assert.strictEqual(platformConfig.accessTokenExpiry, accessTokenExpiry.toISOString());
+    assert.strictEqual(platformConfig.refreshToken, refreshToken);
+    assert.strictEqual(configManager._readFileSync.mock.calls.length, 1);
+    assert.strictEqual(configManager._readFileSync.mock.calls[0].arguments[0], '/test/path');
+    assert.strictEqual(configManager._writeFileSync.mock.calls.length, 1);
+    assert.strictEqual(configManager._writeFileSync.mock.calls[0].arguments[0], '/test/path');
+    assert.strictEqual(configManager._writeFileSync.mock.calls[0].arguments[1], expectedHomebridgeConfig);
+});
+
+test('ConfigManager#updateConfigWithAccessToken does not update the config with existing access token', (context) => {
+    let platformConfig = {
+        'email': null,
+        'password': null,
+        'accessToken': 'testAccessToken',
+        'accessTokenExpiry': '2024-06-12T17:29:20.553Z',
+        'refreshToken': 'testRefreshToken'
+    };
+    let homebridgeConfig = {
+        'platforms': [
+            platformConfig
+        ]
+    };
+    const accessToken = 'testAccessToken';
+    const accessTokenExpiry = new Date('2024-06-12T17:29:20.553Z');
+    const refreshToken = 'testRefreshToken';
+    const configManager = new ConfigManager(platformConfig, mockApi);
+    context.mock.method(
+        configManager,
+        '_readFileSync',
+        (path) => {
+            return JSON.stringify(homebridgeConfig, null, 4);
+        }
+    );
+    context.mock.method(
+        configManager,
+        '_writeFileSync',
+        (path, jsonString) => {}
+    );
+
+    const result = configManager.updateConfigWithAccessToken(
+        accessToken,
+        accessTokenExpiry,
+        refreshToken
+    );
+
+    assert.strictEqual(result, false);
+    assert.strictEqual(platformConfig.email, null);
+    assert.strictEqual(platformConfig.password, null);
+    assert.strictEqual(platformConfig.accessToken, accessToken);
+    assert.strictEqual(platformConfig.accessTokenExpiry, accessTokenExpiry.toISOString());
+    assert.strictEqual(platformConfig.refreshToken, refreshToken);
+    assert.strictEqual(configManager._readFileSync.mock.calls.length, 1);
+    assert.strictEqual(configManager._readFileSync.mock.calls[0].arguments[0], '/test/path');
+    assert.strictEqual(configManager._writeFileSync.mock.calls.length, 0);
+});


### PR DESCRIPTION
After getting an access token from Airstage, we can remove the plaintext email/password from the config, and store the access/refresh tokens there.