### PR TITLE
Add and use `PlatformAccessoryManager`, fix cacheing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ A Homebridge plugin to control devices that use the Fujitsu Airstage API.
 
 ```json
 {
+    "name": "Airstage Platform",
     "platform": "fujitsu-airstage",
     "region": "us",
     "country": "United States",
     "language": "en",
     "email": "test@example.com",
     "password": "test1234",
+    "accessToken": null,
+    "accessTokenExpiry": null,
+    "refreshToken": null,
     "enableThermostat": true,
     "enableFan": true,
     "enableVerticalSlats": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Fujitsu Airstage",
   "name": "homebridge-fujitsu-airstage",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A Homebridge plugin to control devices that use the Fujitsu Airstage API.",
   "license": "MIT",
   "homepage": "https://github.com/PatrickStankard/homebridge-fujitsu-airstage",

--- a/src/accessories/accessory.js
+++ b/src/accessories/accessory.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const airstage = require('./../airstage');
+
+class Accessory {
+
+    constructor(platform, accessory) {
+        this.platform = platform;
+        this.accessory = accessory;
+        this.dynamicServiceCharacteristics = [];
+
+        this.deviceId = this.accessory.context.deviceId;
+        this.airstageClient = this.accessory.context.airstageClient;
+
+        this.accessory.getService(this.platform.Service.AccessoryInformation)
+            .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
+            .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model)
+            .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.deviceId);
+    }
+
+    _refreshDynamicServiceCharacteristics() {
+        this.platform.accessoryManager.refreshServiceCharacteristics(
+            this.service,
+            this.dynamicServiceCharacteristics
+        );
+    }
+
+    _logMethodCall(methodName, value) {
+        let logMessage = '[' + this.constructor.name + '] called ' + methodName;
+
+        if (value) {
+            logMessage = logMessage + ' with value: ' + value;
+        }
+
+        this.platform.log.debug(logMessage);
+    }
+
+    _logMethodCallResult(methodName, error, value) {
+        let logMessage = '[' + this.constructor.name + '] call to ' + methodName;
+
+        if (error) {
+            logMessage = logMessage + ' unsuccessful, resulted in error: ' + error;
+            this.platform.log.error(logMessage);
+        } else {
+            logMessage = logMessage + ' successful';
+            if (value !== null) {
+                logMessage = logMessage + ', resulted in value: ' + value;
+            }
+
+            this.platform.log.debug(logMessage);
+        }
+    }
+}
+
+module.exports = Accessory;

--- a/src/accessories/dry-mode-switch-accessory.js
+++ b/src/accessories/dry-mode-switch-accessory.js
@@ -60,9 +60,7 @@ class DryModeSwitchAccessory {
                     return callback(error);
                 }
 
-                this._updateThermostatServiceCharacteristics();
-                this._updateFanServiceCharacteristics();
-                this._updateFanModeSwitchCharacteristics();
+                this._refreshRelatedAccessoryCharacteristics();
 
                 callback(null);
             }).bind(this)
@@ -79,154 +77,12 @@ class DryModeSwitchAccessory {
         });
     }
 
-    _updateThermostatServiceCharacteristics() {
-        const thermostatService = this._getThermostatService();
+    _refreshRelatedAccessoryCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
 
-        if (thermostatService === null) {
-            return false;
-        }
-
-        const currentHeatingCoolingState = thermostatService.getCharacteristic(
-            this.platform.Characteristic.CurrentHeatingCoolingState
-        );
-        const targetHeatingCoolingState = thermostatService.getCharacteristic(
-            this.platform.Characteristic.TargetHeatingCoolingState
-        );
-
-        currentHeatingCoolingState.emit('get', function(error, value) {
-            if (error === null) {
-                currentHeatingCoolingState.sendEventNotification(value);
-            }
-        });
-
-        targetHeatingCoolingState.emit('get', function(error, value) {
-            if (error === null) {
-                targetHeatingCoolingState.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _updateFanServiceCharacteristics() {
-        const fanService = this._getFanService();
-
-        if (fanService === null) {
-            return false;
-        }
-
-        const active = fanService.getCharacteristic(
-            this.platform.Characteristic.Active
-        );
-        const currentFanState = fanService.getCharacteristic(
-            this.platform.Characteristic.CurrentFanState
-        );
-        const targetFanState = fanService.getCharacteristic(
-            this.platform.Characteristic.TargetFanState
-        );
-        const rotationSpeed = fanService.getCharacteristic(
-            this.platform.Characteristic.RotationSpeed
-        );
-
-        active.emit('get', function(error, value) {
-            if (error === null) {
-                active.sendEventNotification(value);
-            }
-        });
-
-        currentFanState.emit('get', function(error, value) {
-            if (error === null) {
-                currentFanState.sendEventNotification(value);
-            }
-        });
-
-        targetFanState.emit('get', function(error, value) {
-            if (error === null) {
-                targetFanState.sendEventNotification(value);
-            }
-        });
-
-        rotationSpeed.emit('get', function(error, value) {
-            if (error === null) {
-                rotationSpeed.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _updateFanModeSwitchCharacteristics() {
-        const fanModeSwitch = this._getFanModeSwitch();
-
-        if (fanModeSwitch === null) {
-            return false;
-        }
-
-        const on = fanModeSwitch.getCharacteristic(
-            this.platform.Characteristic.On
-        );
-
-        on.emit('get', function(error, value) {
-            if (error === null) {
-                on.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _getThermostatService() {
-        let thermostatService = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-thermostat'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            thermostatService = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Thermostat
-            );
-        }
-
-        return thermostatService;
-    }
-
-    _getFanService() {
-        let fanService = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-fan'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            fanService = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Fanv2
-            );
-        }
-
-        return fanService;
-    }
-
-    _getFanModeSwitch() {
-        let fanModeSwitch = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-fan-mode-switch'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            fanModeSwitch = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Switch
-            );
-        }
-
-        return fanModeSwitch;
+        accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshFanModeSwitchAccessoryCharacteristics(this.deviceId);
     }
 }
 

--- a/src/accessories/dry-mode-switch-accessory.js
+++ b/src/accessories/dry-mode-switch-accessory.js
@@ -82,9 +82,9 @@ class DryModeSwitchAccessory extends Accessory {
 
                         this._logMethodCallResult(methodName, null, null);
 
-                        callback(null);
-
                         this._refreshRelatedAccessoryCharacteristics();
+
+                        callback(null);
                     }).bind(this)
                 );
             }).bind(this)

--- a/src/accessories/energy-saving-fan-switch-accessory.js
+++ b/src/accessories/energy-saving-fan-switch-accessory.js
@@ -1,20 +1,12 @@
 'use strict';
 
+const Accessory = require('./accessory');
 const airstage = require('./../airstage');
 
-class EnergySavingFanSwitchAccessory {
+class EnergySavingFanSwitchAccessory extends Accessory {
 
     constructor(platform, accessory) {
-        this.platform = platform;
-        this.accessory = accessory;
-
-        this.deviceId = this.accessory.context.deviceId;
-        this.airstageClient = this.accessory.context.airstageClient;
-
-        this.accessory.getService(this.platform.Service.AccessoryInformation)
-            .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
-            .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.deviceId);
+        super(platform, accessory);
 
         this.service = (
             this.accessory.getService(this.platform.Service.Switch) ||
@@ -30,24 +22,39 @@ class EnergySavingFanSwitchAccessory {
     }
 
     getOn(callback) {
-        this.airstageClient.getEnergySavingFanState(this.deviceId, function(error, energySavingFanState) {
-            let value = null;
+        const methodName = this.getOn.name;
 
-            if (error) {
-                return callback(error, null);
-            }
+        this._logMethodCall(methodName);
 
-            if (energySavingFanState === airstage.constants.TOGGLE_ON) {
-                value = true;
-            } else if (energySavingFanState === airstage.constants.TOGGLE_OFF) {
-                value = false;
-            }
+        this.airstageClient.getEnergySavingFanState(
+            this.deviceId,
+            (function(error, energySavingFanState) {
+                let value = null;
 
-            callback(null, value);
-        });
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (energySavingFanState === airstage.constants.TOGGLE_ON) {
+                    value = true;
+                } else if (energySavingFanState === airstage.constants.TOGGLE_OFF) {
+                    value = false;
+                }
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     setOn(value, callback) {
+        const methodName = this.setOn.name;
+
+        this._logMethodCall(methodName, value);
+
         let energySavingFanState = null;
 
         if (value) {
@@ -59,20 +66,41 @@ class EnergySavingFanSwitchAccessory {
         this.airstageClient.setEnergySavingFanState(
             this.deviceId,
             energySavingFanState,
-            function(error) {
-                callback(error);
-            }
+            (function(error) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error);
+                }
+
+                this._logMethodCallResult(methodName, null, null);
+
+                callback(null);
+            }).bind(this)
         );
     }
 
     getName(callback) {
-        this.airstageClient.getName(this.deviceId, function(error, name) {
-            if (error) {
-                return callback(error, null);
-            }
+        const methodName = this.getName.name;
 
-            callback(null, name + ' Energy Saving Fan Switch');
-        });
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getName(
+            this.deviceId,
+            (function(error, name) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                const value = name + ' Energy Saving Fan Switch';
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 }
 

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -76,7 +76,7 @@ class FanAccessory {
                 return callback(error);
             }
 
-            this._updateThermostatServiceCharacteristics();
+            this._refreshRelatedAccessoryCharacteristics();
 
             callback(null);
         }).bind(this));
@@ -242,51 +242,10 @@ class FanAccessory {
         );
     }
 
-    _updateThermostatServiceCharacteristics() {
-        const thermostatService = this._getThermostatService();
+    _refreshRelatedAccessoryCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
 
-        if (thermostatService === null) {
-            return false;
-        }
-
-        const currentHeatingCoolingState = thermostatService.getCharacteristic(
-            this.platform.Characteristic.CurrentHeatingCoolingState
-        );
-        const targetHeatingCoolingState = thermostatService.getCharacteristic(
-            this.platform.Characteristic.TargetHeatingCoolingState
-        );
-
-        currentHeatingCoolingState.emit('get', function(error, value) {
-            if (error === null) {
-                currentHeatingCoolingState.sendEventNotification(value);
-            }
-        });
-
-        targetHeatingCoolingState.emit('get', function(error, value) {
-            if (error === null) {
-                targetHeatingCoolingState.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _getThermostatService() {
-        let thermostatService = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-thermostat'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            thermostatService = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Thermostat
-            );
-        }
-
-        return thermostatService;
+        accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
     }
 }
 

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -1,33 +1,28 @@
 'use strict';
 
+const Accessory = require('./accessory');
 const airstage = require('./../airstage');
 
-class FanAccessory {
+class FanAccessory extends Accessory {
 
     constructor(platform, accessory) {
-        this.platform = platform;
-        this.accessory = accessory;
-
-        this.deviceId = this.accessory.context.deviceId;
-        this.airstageClient = this.accessory.context.airstageClient;
-
-        this.accessory.getService(this.platform.Service.AccessoryInformation)
-            .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
-            .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.deviceId);
+        super(platform, accessory);
 
         this.service = (
             this.accessory.getService(this.platform.Service.Fanv2) ||
             this.accessory.addService(this.platform.Service.Fanv2)
         );
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.Active);
         this.service.getCharacteristic(this.platform.Characteristic.Active)
             .on('get', this.getActive.bind(this))
             .on('set', this.setActive.bind(this));
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.CurrentFanState);
         this.service.getCharacteristic(this.platform.Characteristic.CurrentFanState)
             .on('get', this.getCurrentFanState.bind(this));
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.TargetFanState);
         this.service.getCharacteristic(this.platform.Characteristic.TargetFanState)
             .on('get', this.getTargetFanState.bind(this))
             .on('set', this.setTargetFanState.bind(this));
@@ -35,6 +30,7 @@ class FanAccessory {
         this.service.getCharacteristic(this.platform.Characteristic.Name)
             .on('get', this.getName.bind(this));
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.RotationSpeed);
         this.service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
             .on('get', this.getRotationSpeed.bind(this))
             .on('set', this.setRotationSpeed.bind(this));
@@ -42,27 +38,44 @@ class FanAccessory {
         this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
             .on('get', this.getSwingMode.bind(this))
             .on('set', this.setSwingMode.bind(this));
+
+        this._setFanSpeedHandle = null;
     }
 
     getActive(callback) {
-        this.airstageClient.getPowerState(this.deviceId, (function(error, powerState) {
-            let value = null;
+        const methodName = this.getActive.name;
 
-            if (error) {
-                return callback(error, null);
-            }
+        this._logMethodCall(methodName);
 
-            if (powerState === airstage.constants.TOGGLE_ON) {
-                value = this.platform.Characteristic.Active.ACTIVE;
-            } else if (powerState === airstage.constants.TOGGLE_OFF) {
-                value = this.platform.Characteristic.Active.INACTIVE;
-            }
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
+                let value = null;
 
-            callback(null, value);
-        }).bind(this));
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (powerState === airstage.constants.TOGGLE_ON) {
+                    value = this.platform.Characteristic.Active.ACTIVE;
+                } else if (powerState === airstage.constants.TOGGLE_OFF) {
+                    value = this.platform.Characteristic.Active.INACTIVE;
+                }
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     setActive(value, callback) {
+        const methodName = this.setActive.name;
+
+        this._logMethodCall(methodName, value);
+
         let powerState = null;
 
         if (value === this.platform.Characteristic.Active.ACTIVE) {
@@ -71,106 +84,175 @@ class FanAccessory {
             powerState = airstage.constants.TOGGLE_OFF;
         }
 
-        this.airstageClient.setPowerState(this.deviceId, powerState, (function(error) {
-            if (error) {
-                return callback(error);
-            }
-
-            this._refreshRelatedAccessoryCharacteristics();
-
-            callback(null);
-        }).bind(this));
-    }
-
-    getCurrentFanState(callback) {
-        this.airstageClient.getPowerState(this.deviceId, (function(error, powerState) {
-            let value = null;
-
-            if (error) {
-                return callback(error, null);
-            }
-
-            if (powerState === airstage.constants.TOGGLE_ON) {
-                value = this.platform.Characteristic.CurrentFanState.BLOWING_AIR;
-            } else if (powerState === airstage.constants.TOGGLE_OFF) {
-                value = this.platform.Characteristic.CurrentFanState.INACTIVE;
-            }
-
-            callback(null, value);
-        }).bind(this));
-    }
-
-    getTargetFanState(callback) {
-        this.airstageClient.getFanSpeed(this.deviceId, (function(error, fanSpeed) {
-            let value = this.platform.Characteristic.TargetFanState.MANUAL;
-
-            if (error) {
-                return callback(error, null);
-            }
-
-            if (fanSpeed === airstage.constants.FAN_SPEED_AUTO) {
-                value = this.platform.Characteristic.TargetFanState.AUTO;
-            }
-
-            callback(null, value);
-        }).bind(this));
-    }
-
-    setTargetFanState(value, callback) {
-        if (value !== this.platform.Characteristic.TargetFanState.AUTO) {
-            this._refreshCurrentCharacteristics();
-
-            return callback(null);
-        }
-
-        this.airstageClient.setFanSpeed(
+        this.airstageClient.setPowerState(
             this.deviceId,
-            airstage.constants.FAN_SPEED_AUTO,
+            powerState,
             (function(error) {
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error);
                 }
 
-                this._refreshCurrentCharacteristics();
+                this._logMethodCallResult(methodName, null, null);
 
                 callback(null);
+
+                this._refreshDynamicServiceCharacteristics();
+                this._refreshRelatedAccessoryCharacteristics();
             }).bind(this)
         );
     }
 
-    getName(callback) {
-        this.airstageClient.getName(this.deviceId, function(error, name) {
-            if (error) {
-                return callback(error, null);
-            }
+    getCurrentFanState(callback) {
+        const methodName = this.getCurrentFanState.name;
 
-            callback(null, name + ' Fan');
-        });
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
+                let value = null;
+
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (powerState === airstage.constants.TOGGLE_ON) {
+                    value = this.platform.Characteristic.CurrentFanState.BLOWING_AIR;
+                } else if (powerState === airstage.constants.TOGGLE_OFF) {
+                    value = this.platform.Characteristic.CurrentFanState.INACTIVE;
+                }
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
+    }
+
+    getTargetFanState(callback) {
+        const methodName = this.getTargetFanState.name;
+
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getFanSpeed(
+            this.deviceId,
+            (function(error, fanSpeed) {
+                let value = this.platform.Characteristic.TargetFanState.MANUAL;
+
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (fanSpeed === airstage.constants.FAN_SPEED_AUTO) {
+                    value = this.platform.Characteristic.TargetFanState.AUTO;
+                }
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
+    }
+
+    setTargetFanState(value, callback) {
+        const methodName = this.setTargetFanState.name;
+
+        this._logMethodCall(methodName, value);
+
+        if (value === this.platform.Characteristic.TargetFanState.AUTO) {
+            this.airstageClient.setFanSpeed(
+                this.deviceId,
+                airstage.constants.FAN_SPEED_AUTO,
+                (function(error) {
+                    if (error) {
+                        this._logMethodCallResult(methodName, error);
+
+                        return callback(error);
+                    }
+
+                    this._logMethodCallResult(methodName, null, null);
+
+                    callback(null);
+
+                    this._refreshDynamicServiceCharacteristics();
+                }).bind(this)
+            );
+        } else {
+            this._logMethodCallResult(methodName, null, null);
+
+            callback(null);
+        }
+    }
+
+    getName(callback) {
+        const methodName = this.getName.name;
+
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getName(
+            this.deviceId,
+            (function(error, name) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                const value = name + ' Fan';
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     getRotationSpeed(callback) {
-        this.airstageClient.getFanSpeed(this.deviceId, (function(error, fanSpeed) {
-            let value = 0;
+        const methodName = this.getRotationSpeed.name;
 
-            if (error) {
-                return callback(error, null);
-            }
+        this._logMethodCall(methodName);
 
-            if (fanSpeed === airstage.constants.FAN_SPEED_QUIET) {
-                value = 25;
-            } else if (fanSpeed === airstage.constants.FAN_SPEED_LOW) {
-                value = 50;
-            } else if (fanSpeed === airstage.constants.FAN_SPEED_MEDIUM) {
-                value = 75;
-            } else if (fanSpeed === airstage.constants.FAN_SPEED_HIGH) {
-                value = 100;
-            }
+        this.airstageClient.getFanSpeed(
+            this.deviceId,
+            (function(error, fanSpeed) {
+                let value = null;
 
-            callback(null, value);
-        }).bind(this));
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (fanSpeed === airstage.constants.FAN_SPEED_AUTO) {
+                    value = 0;
+                } else if (fanSpeed === airstage.constants.FAN_SPEED_QUIET) {
+                    value = 25;
+                } else if (fanSpeed === airstage.constants.FAN_SPEED_LOW) {
+                    value = 50;
+                } else if (fanSpeed === airstage.constants.FAN_SPEED_MEDIUM) {
+                    value = 75;
+                } else if (fanSpeed === airstage.constants.FAN_SPEED_HIGH) {
+                    value = 100;
+                }
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     setRotationSpeed(value, callback) {
+        const methodName = this.setRotationSpeed.name;
+
+        this._logMethodCall(methodName, value);
+
         let fanSpeed = null;
 
         if (value <= 25) {
@@ -183,31 +265,36 @@ class FanAccessory {
             fanSpeed = airstage.constants.FAN_SPEED_HIGH;
         }
 
-        this.airstageClient.setFanSpeed(
-            this.deviceId,
-            fanSpeed,
-            (function(error) {
-                if (error) {
-                    return callback(error);
-                }
+        if (this._setFanSpeedHandle !== null) {
+            clearTimeout(this._setFanSpeedHandle);
+            this._setFanSpeedHandle = null;
+        }
 
-                this._refreshCurrentCharacteristics();
-
-                callback(null);
-            }).bind(this)
+        this._setFanSpeedHandle = setTimeout(
+            (function() {
+                this._setFanSpeed(methodName, fanSpeed);
+            }).bind(this),
+            500
         );
+
+        callback(null);
     }
 
     getSwingMode(callback) {
+        const methodName = this.getSwingMode.name;
+
+        this._logMethodCall(methodName);
+
         this.airstageClient.getAirflowVerticalSwingState(
             this.deviceId,
             (function(error, swingState) {
                 let value = null;
 
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error, null);
                 }
-
 
                 if (swingState === airstage.constants.TOGGLE_ON) {
                     value = this.platform.Characteristic.SwingMode.SWING_ENABLED;
@@ -215,12 +302,18 @@ class FanAccessory {
                     value = this.platform.Characteristic.SwingMode.SWING_DISABLED;
                 }
 
+                this._logMethodCallResult(methodName, null, value);
+
                 callback(null, value);
             }).bind(this)
         );
     }
 
     setSwingMode(value, callback) {
+        const methodName = this.setSwingMode.name;
+
+        this._logMethodCall(methodName, value);
+
         let swingState = null;
 
         if (value === this.platform.Characteristic.SwingMode.SWING_ENABLED) {
@@ -232,9 +325,37 @@ class FanAccessory {
         this.airstageClient.setAirflowVerticalSwingState(
             this.deviceId,
             swingState,
-            function(error) {
-                callback(error);
-            }
+            (function(error) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error);
+                }
+
+                this._logMethodCallResult(methodName, null, null);
+
+                callback(null);
+            }).bind(this)
+        );
+    }
+
+    _setFanSpeed(methodName, fanSpeed) {
+        this.airstageClient.setFanSpeed(
+            this.deviceId,
+            fanSpeed,
+            (function(error) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return;
+                }
+
+                this._logMethodCallResult(methodName, null, null);
+
+                this._refreshDynamicServiceCharacteristics();
+
+                this._setFanSpeedHandle = null;
+            }).bind(this)
         );
     }
 
@@ -242,19 +363,6 @@ class FanAccessory {
         const accessoryManager = this.platform.accessoryManager;
 
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
-    }
-
-    _refreshCurrentCharacteristics() {
-        const accessoryManager = this.platform.accessoryManager;
-
-        accessoryManager.refreshServiceCharacteristics(
-            this.service,
-            [
-                this.platform.Characteristic.CurrentFanState,
-                this.platform.Characteristic.TargetFanState,
-                this.platform.Characteristic.RotationSpeed
-            ]
-        );
     }
 }
 

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -118,6 +118,8 @@ class FanAccessory {
 
     setTargetFanState(value, callback) {
         if (value !== this.platform.Characteristic.TargetFanState.AUTO) {
+            this._refreshCurrentCharacteristics();
+
             return callback(null);
         }
 
@@ -129,10 +131,7 @@ class FanAccessory {
                     return callback(error);
                 }
 
-                this.service.updateCharacteristic(
-                    this.platform.Characteristic.RotationSpeed,
-                    0
-                );
+                this._refreshCurrentCharacteristics();
 
                 callback(null);
             }).bind(this)
@@ -192,10 +191,7 @@ class FanAccessory {
                     return callback(error);
                 }
 
-                this.service.updateCharacteristic(
-                    this.platform.Characteristic.TargetFanState,
-                    this.platform.Characteristic.TargetFanState.MANUAL
-                );
+                this._refreshCurrentCharacteristics();
 
                 callback(null);
             }).bind(this)
@@ -246,6 +242,19 @@ class FanAccessory {
         const accessoryManager = this.platform.accessoryManager;
 
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
+    }
+
+    _refreshCurrentCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
+
+        accessoryManager.refreshServiceCharacteristics(
+            this.service,
+            [
+                this.platform.Characteristic.CurrentFanState,
+                this.platform.Characteristic.TargetFanState,
+                this.platform.Characteristic.RotationSpeed
+            ]
+        );
     }
 }
 

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -96,10 +96,10 @@ class FanAccessory extends Accessory {
 
                 this._logMethodCallResult(methodName, null, null);
 
-                callback(null);
-
                 this._refreshDynamicServiceCharacteristics();
                 this._refreshRelatedAccessoryCharacteristics();
+
+                callback(null);
             }).bind(this)
         );
     }
@@ -178,9 +178,9 @@ class FanAccessory extends Accessory {
 
                     this._logMethodCallResult(methodName, null, null);
 
-                    callback(null);
-
                     this._refreshDynamicServiceCharacteristics();
+
+                    callback(null);
                 }).bind(this)
             );
         } else {

--- a/src/accessories/fan-mode-switch-accessory.js
+++ b/src/accessories/fan-mode-switch-accessory.js
@@ -82,9 +82,9 @@ class FanModeSwitchAccessory extends Accessory {
 
                         this._logMethodCallResult(methodName, null, null);
 
-                        callback(null);
-
                         this._refreshRelatedAccessoryCharacteristics();
+
+                        callback(null);
                     }).bind(this)
                 );
             }).bind(this)

--- a/src/accessories/fan-mode-switch-accessory.js
+++ b/src/accessories/fan-mode-switch-accessory.js
@@ -60,8 +60,7 @@ class FanModeSwitchAccessory {
                     return callback(error);
                 }
 
-                this._updateThermostatServiceCharacteristics();
-                this._updateDryModeSwitchCharacteristics();
+                this._refreshRelatedAccessoryCharacteristics();
 
                 callback(null);
             }).bind(this)
@@ -78,89 +77,11 @@ class FanModeSwitchAccessory {
         });
     }
 
-    _updateThermostatServiceCharacteristics() {
-        const thermostatService = this._getThermostatService();
+    _refreshRelatedAccessoryCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
 
-        if (thermostatService === null) {
-            return false;
-        }
-
-        const currentHeatingCoolingState = thermostatService.getCharacteristic(
-            this.platform.Characteristic.CurrentHeatingCoolingState
-        );
-        const targetHeatingCoolingState = thermostatService.getCharacteristic(
-            this.platform.Characteristic.TargetHeatingCoolingState
-        );
-
-        currentHeatingCoolingState.emit('get', function(error, value) {
-            if (error === null) {
-                currentHeatingCoolingState.sendEventNotification(value);
-            }
-        });
-
-        targetHeatingCoolingState.emit('get', function(error, value) {
-            if (error === null) {
-                targetHeatingCoolingState.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _updateDryModeSwitchCharacteristics() {
-        const dryModeSwitch = this._getDryModeSwitch();
-
-        if (dryModeSwitch === null) {
-            return false;
-        }
-
-        const on = dryModeSwitch.getCharacteristic(
-            this.platform.Characteristic.On
-        );
-
-        on.emit('get', function(error, value) {
-            if (error === null) {
-                on.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _getThermostatService() {
-        let thermostatService = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-thermostat'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            thermostatService = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Thermostat
-            );
-        }
-
-        return thermostatService;
-    }
-
-    _getDryModeSwitch() {
-        let dryModeSwitch = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-dry-mode-switch'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            dryModeSwitch = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Switch
-            );
-        }
-
-        return dryModeSwitch;
+        accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
     }
 }
 

--- a/src/accessories/fan-mode-switch-accessory.js
+++ b/src/accessories/fan-mode-switch-accessory.js
@@ -1,21 +1,14 @@
 'use strict';
 
+const Accessory = require('./accessory');
 const airstage = require('./../airstage');
 
-class FanModeSwitchAccessory {
+class FanModeSwitchAccessory extends Accessory {
 
     constructor(platform, accessory) {
-        this.platform = platform;
-        this.accessory = accessory;
+        super(platform, accessory);
 
-        this.deviceId = this.accessory.context.deviceId;
-        this.airstageClient = this.accessory.context.airstageClient;
         this.lastKnownOperationMode = null;
-
-        this.accessory.getService(this.platform.Service.AccessoryInformation)
-            .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
-            .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.deviceId);
 
         this.service = (
             this.accessory.getService(this.platform.Service.Switch) ||
@@ -31,20 +24,35 @@ class FanModeSwitchAccessory {
     }
 
     getOn(callback) {
-        this.airstageClient.getOperationMode(this.deviceId, function(error, operationMode) {
-            let value = null;
+        const methodName = this.getOn.name;
 
-            if (error) {
-                return callback(error, null);
-            }
+        this._logMethodCall(methodName);
 
-            value = (operationMode === airstage.constants.OPERATION_MODE_FAN);
+        this.airstageClient.getOperationMode(
+            this.deviceId,
+            (function(error, operationMode) {
+                let value = null;
 
-            callback(null, value);
-        });
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                value = (operationMode === airstage.constants.OPERATION_MODE_FAN);
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     setOn(value, callback) {
+        const methodName = this.setOn.name;
+
+        this._logMethodCall(methodName, value);
+
         let operationMode = null;
 
         if (value) {
@@ -67,12 +75,16 @@ class FanModeSwitchAccessory {
                     operationMode,
                     (function(error) {
                         if (error) {
+                            this._logMethodCallResult(methodName, error);
+
                             return callback(error);
                         }
 
-                        this._refreshRelatedAccessoryCharacteristics();
+                        this._logMethodCallResult(methodName, null, null);
 
                         callback(null);
+
+                        this._refreshRelatedAccessoryCharacteristics();
                     }).bind(this)
                 );
             }).bind(this)
@@ -80,13 +92,26 @@ class FanModeSwitchAccessory {
     }
 
     getName(callback) {
-        this.airstageClient.getName(this.deviceId, function(error, name) {
-            if (error) {
-                return callback(error, null);
-            }
+        const methodName = this.getName.name;
 
-            callback(null, name + ' Fan Mode Switch');
-        });
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getName(
+            this.deviceId,
+            (function(error, name) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                const value = name + ' Fan Mode Switch';
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     _refreshRelatedAccessoryCharacteristics() {

--- a/src/accessories/fan-mode-switch-accessory.js
+++ b/src/accessories/fan-mode-switch-accessory.js
@@ -10,6 +10,7 @@ class FanModeSwitchAccessory {
 
         this.deviceId = this.accessory.context.deviceId;
         this.airstageClient = this.accessory.context.airstageClient;
+        this.lastKnownOperationMode = null;
 
         this.accessory.getService(this.platform.Service.AccessoryInformation)
             .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
@@ -49,20 +50,31 @@ class FanModeSwitchAccessory {
         if (value) {
             operationMode = airstage.constants.OPERATION_MODE_FAN;
         } else {
-            operationMode = airstage.constants.OPERATION_MODE_AUTO;
+            if (this.lastKnownOperationMode !== null) {
+                operationMode = this.lastKnownOperationMode;
+            } else {
+                operationMode = airstage.constants.OPERATION_MODE_AUTO;
+            }
         }
 
-        this.airstageClient.setOperationMode(
+        this.airstageClient.getOperationMode(
             this.deviceId,
-            operationMode,
-            (function(error) {
-                if (error) {
-                    return callback(error);
-                }
+            (function(error, currentOperationMode) {
+                this.lastKnownOperationMode = currentOperationMode;
 
-                this._refreshRelatedAccessoryCharacteristics();
+                this.airstageClient.setOperationMode(
+                    this.deviceId,
+                    operationMode,
+                    (function(error) {
+                        if (error) {
+                            return callback(error);
+                        }
 
-                callback(null);
+                        this._refreshRelatedAccessoryCharacteristics();
+
+                        callback(null);
+                    }).bind(this)
+                );
             }).bind(this)
         );
     }

--- a/src/accessories/powerful-switch-accessory.js
+++ b/src/accessories/powerful-switch-accessory.js
@@ -1,20 +1,12 @@
 'use strict';
 
+const Accessory = require('./accessory');
 const airstage = require('./../airstage');
 
-class PowerfulSwitchAccessory {
+class PowerfulSwitchAccessory extends Accessory {
 
     constructor(platform, accessory) {
-        this.platform = platform;
-        this.accessory = accessory;
-
-        this.deviceId = this.accessory.context.deviceId;
-        this.airstageClient = this.accessory.context.airstageClient;
-
-        this.accessory.getService(this.platform.Service.AccessoryInformation)
-            .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
-            .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.deviceId);
+        super(platform, accessory);
 
         this.service = (
             this.accessory.getService(this.platform.Service.Switch) ||
@@ -30,24 +22,39 @@ class PowerfulSwitchAccessory {
     }
 
     getOn(callback) {
-        this.airstageClient.getPowerfulState(this.deviceId, function(error, powerfulState) {
-            let value = null;
+        const methodName = this.getOn.name;
 
-            if (error) {
-                return callback(error, null);
-            }
+        this._logMethodCall(methodName);
 
-            if (powerfulState === airstage.constants.TOGGLE_ON) {
-                value = true;
-            } else if (powerfulState === airstage.constants.TOGGLE_OFF) {
-                value = false;
-            }
+        this.airstageClient.getPowerfulState(
+            this.deviceId,
+            (function(error, powerfulState) {
+                let value = null;
 
-            callback(null, value);
-        });
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (powerfulState === airstage.constants.TOGGLE_ON) {
+                    value = true;
+                } else if (powerfulState === airstage.constants.TOGGLE_OFF) {
+                    value = false;
+                }
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     setOn(value, callback) {
+        const methodName = this.setOn.name;
+
+        this._logMethodCall(methodName, value);
+
         let powerfulState = null;
 
         if (value) {
@@ -59,20 +66,41 @@ class PowerfulSwitchAccessory {
         this.airstageClient.setPowerfulState(
             this.deviceId,
             powerfulState,
-            function(error) {
-                callback(error);
-            }
+            (function(error) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error);
+                }
+
+                this._logMethodCallResult(methodName, null, null);
+
+                callback(null);
+            }).bind(this)
         );
     }
 
     getName(callback) {
-        this.airstageClient.getName(this.deviceId, function(error, name) {
-            if (error) {
-                return callback(error, null);
-            }
+        const methodName = this.getName.name;
 
-            callback(null, name + ' Powerful Switch');
-        });
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getName(
+            this.deviceId,
+            (function(error, name) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                const value = name + ' Powerful Switch';
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 }
 

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -1,36 +1,32 @@
 'use strict';
 
+const Accessory = require('./accessory');
 const airstage = require('./../airstage');
 
-class ThermostatAccessory {
+class ThermostatAccessory extends Accessory {
 
     constructor(platform, accessory) {
-        this.platform = platform;
-        this.accessory = accessory;
-
-        this.deviceId = this.accessory.context.deviceId;
-        this.airstageClient = this.accessory.context.airstageClient;
-
-        this.accessory.getService(this.platform.Service.AccessoryInformation)
-            .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
-            .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.deviceId);
+        super(platform, accessory);
 
         this.service = (
             this.accessory.getService(this.platform.Service.Thermostat) ||
             this.accessory.addService(this.platform.Service.Thermostat)
         );
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.CurrentHeatingCoolingState);
         this.service.getCharacteristic(this.platform.Characteristic.CurrentHeatingCoolingState)
             .on('get', this.getCurrentHeatingCoolingState.bind(this));
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.TargetHeatingCoolingState);
         this.service.getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState)
             .on('get', this.getTargetHeatingCoolingState.bind(this))
             .on('set', this.setTargetHeatingCoolingState.bind(this));
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.CurrentTemperature);
         this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
             .on('get', this.getCurrentTemperature.bind(this));
 
+        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.TargetTemperature);
         this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature)
             .on('get', this.getTargetTemperature.bind(this))
             .on('set', this.setTargetTemperature.bind(this));
@@ -44,100 +40,140 @@ class ThermostatAccessory {
     }
 
     getCurrentHeatingCoolingState(callback) {
-        this.airstageClient.getPowerState(this.deviceId, (function(error, powerState) {
-            if (error) {
-                return callback(error, null);
-            }
+        const methodName = this.getCurrentHeatingCoolingState.name;
 
-            if (powerState === airstage.constants.TOGGLE_OFF) {
-                return callback(
-                    null,
-                    this.platform.Characteristic.CurrentHeatingCoolingState.OFF
-                );
-            }
+        this._logMethodCall(methodName);
 
-            this.airstageClient.getOperationMode(this.deviceId, (function(error, operationMode) {
-                let currentHeatingCoolingState = null;
-
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error, null);
                 }
 
-                if (operationMode === airstage.constants.OPERATION_MODE_AUTO) {
-                    return this.airstageClient.getTemperatureDelta(
-                        this.deviceId,
-                        airstage.constants.TEMPERATURE_SCALE_CELSIUS,
-                        (function(error, temperatureDelta) {
-                            if (error) {
-                                return callback(error, null);
-                            }
-
-                            if (temperatureDelta > 0) {
-                                currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
-                            } else if (temperatureDelta < 0) {
-                                currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
-                            } else {
-                                currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.OFF;
-                            }
-
-                            callback(null, currentHeatingCoolingState);
-                        }).bind(this)
+                if (powerState === airstage.constants.TOGGLE_OFF) {
+                    return callback(
+                        null,
+                        this.platform.Characteristic.CurrentHeatingCoolingState.OFF
                     );
                 }
 
-                if (operationMode === airstage.constants.OPERATION_MODE_COOL) {
-                    currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
-                } else if (operationMode === airstage.constants.OPERATION_MODE_DRY) {
-                    currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
-                } else if (operationMode === airstage.constants.OPERATION_MODE_FAN) {
-                    currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.OFF;
-                } else if (operationMode === airstage.constants.OPERATION_MODE_HEAT) {
-                    currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
-                }
+                this.airstageClient.getOperationMode(
+                    this.deviceId,
+                    (function(error, operationMode) {
+                        let currentHeatingCoolingState = null;
 
-                callback(null, currentHeatingCoolingState);
-            }).bind(this));
-        }).bind(this));
+                        if (error) {
+                            this._logMethodCallResult(methodName, error);
+
+                            return callback(error, null);
+                        }
+
+                        if (operationMode === airstage.constants.OPERATION_MODE_AUTO) {
+                            return this.airstageClient.getTemperatureDelta(
+                                this.deviceId,
+                                airstage.constants.TEMPERATURE_SCALE_CELSIUS,
+                                (function(error, temperatureDelta) {
+                                    if (error) {
+                                        this._logMethodCallResult(methodName, error);
+
+                                        return callback(error, null);
+                                    }
+
+                                    if (temperatureDelta > 0) {
+                                        currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
+                                    } else if (temperatureDelta < 0) {
+                                        currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
+                                    } else {
+                                        currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.OFF;
+                                    }
+
+                                    this._logMethodCallResult(methodName, null, currentHeatingCoolingState);
+
+                                    callback(null, currentHeatingCoolingState);
+                                }).bind(this)
+                            );
+                        }
+
+                        if (operationMode === airstage.constants.OPERATION_MODE_COOL) {
+                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
+                        } else if (operationMode === airstage.constants.OPERATION_MODE_DRY) {
+                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
+                        } else if (operationMode === airstage.constants.OPERATION_MODE_FAN) {
+                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.OFF;
+                        } else if (operationMode === airstage.constants.OPERATION_MODE_HEAT) {
+                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
+                        }
+
+                        this._logMethodCallResult(methodName, null, currentHeatingCoolingState);
+
+                        callback(null, currentHeatingCoolingState);
+                    }).bind(this)
+                );
+            }).bind(this)
+        );
     }
 
     getTargetHeatingCoolingState(callback) {
-        this.airstageClient.getPowerState(this.deviceId, (function(error, powerState) {
-            if (error) {
-                return callback(error, null);
-            }
+        const methodName = this.getTargetHeatingCoolingState.name;
 
-            if (powerState === airstage.constants.TOGGLE_OFF) {
-                return callback(
-                    null,
-                    this.platform.Characteristic.TargetHeatingCoolingState.OFF
-                );
-            }
+        this._logMethodCall(methodName);
 
-            this.airstageClient.getOperationMode(this.deviceId, (function(error, operationMode) {
-                let targetHeatingCoolingState = null;
-
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error, null);
                 }
 
-                if (operationMode === airstage.constants.OPERATION_MODE_COOL) {
-                    targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.COOL;
-                } else if (operationMode === airstage.constants.OPERATION_MODE_DRY) {
-                    targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.COOL;
-                } else if (operationMode === airstage.constants.OPERATION_MODE_FAN) {
-                    targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.OFF;
-                } else if (operationMode === airstage.constants.OPERATION_MODE_HEAT) {
-                    targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.HEAT;
-                } else if (operationMode === airstage.constants.OPERATION_MODE_AUTO) {
-                    targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.AUTO;
+                if (powerState === airstage.constants.TOGGLE_OFF) {
+                    return callback(
+                        null,
+                        this.platform.Characteristic.TargetHeatingCoolingState.OFF
+                    );
                 }
 
-                callback(null, targetHeatingCoolingState);
-            }).bind(this));
-        }).bind(this));
+                this.airstageClient.getOperationMode(
+                    this.deviceId,
+                    (function(error, operationMode) {
+                        let targetHeatingCoolingState = null;
+
+                        if (error) {
+                            this._logMethodCallResult(methodName, error);
+
+                            return callback(error, null);
+                        }
+
+                        if (operationMode === airstage.constants.OPERATION_MODE_COOL) {
+                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.COOL;
+                        } else if (operationMode === airstage.constants.OPERATION_MODE_DRY) {
+                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.COOL;
+                        } else if (operationMode === airstage.constants.OPERATION_MODE_FAN) {
+                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.OFF;
+                        } else if (operationMode === airstage.constants.OPERATION_MODE_HEAT) {
+                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.HEAT;
+                        } else if (operationMode === airstage.constants.OPERATION_MODE_AUTO) {
+                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.AUTO;
+                        }
+
+                        this._logMethodCallResult(methodName, null, targetHeatingCoolingState);
+
+                        callback(null, targetHeatingCoolingState);
+                    }).bind(this)
+                );
+            }).bind(this)
+        );
     }
 
     setTargetHeatingCoolingState(value, callback) {
+        const methodName = this.setTargetHeatingCoolingState.name;
+
+        this._logMethodCall(methodName, value);
+
         let operationMode = null;
 
         if (value === this.platform.Characteristic.TargetHeatingCoolingState.OFF) {
@@ -146,13 +182,17 @@ class ThermostatAccessory {
                 airstage.constants.TOGGLE_OFF,
                 (function(error) {
                     if (error) {
+                        this._logMethodCallResult(methodName, error);
+
                         return callback(error);
                     }
 
-                    this._refreshRelatedAccessoryCharacteristics();
-                    this._refreshCurrentCharacteristics();
+                    this._logMethodCallResult(methodName, null, null);
 
                     callback(null);
+
+                    this._refreshDynamicServiceCharacteristics();
+                    this._refreshRelatedAccessoryCharacteristics();
                 }).bind(this)
             );
         }
@@ -162,6 +202,8 @@ class ThermostatAccessory {
             airstage.constants.TOGGLE_ON,
             (function(error) {
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error);
                 }
 
@@ -178,13 +220,17 @@ class ThermostatAccessory {
                     operationMode,
                     (function(error) {
                         if (error) {
+                            this._logMethodCallResult(methodName, error);
+
                             return callback(error);
                         }
 
-                        this._refreshRelatedAccessoryCharacteristics();
-                        this._refreshCurrentCharacteristics();
+                        this._logMethodCallResult(methodName, null, null);
 
                         callback(null);
+
+                        this._refreshDynamicServiceCharacteristics();
+                        this._refreshRelatedAccessoryCharacteristics();
                     }).bind(this)
                 );
             }).bind(this)
@@ -192,69 +238,107 @@ class ThermostatAccessory {
     }
 
     getCurrentTemperature(callback) {
+        const methodName = this.getCurrentTemperature.name;
+
+        this._logMethodCall(methodName);
+
         this.airstageClient.getIndoorTemperature(
             this.deviceId,
             airstage.constants.TEMPERATURE_SCALE_CELSIUS,
-            function (error, indoorTemperature) {
+            (function (error, indoorTemperature) {
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error, null);
                 }
 
+                this._logMethodCallResult(methodName, null, indoorTemperature);
+
                 callback(null, indoorTemperature);
-            }
+            }).bind(this)
         );
     }
 
     getTargetTemperature(callback) {
+        const methodName = this.getTargetTemperature.name;
+
+        this._logMethodCall(methodName);
+
         this.airstageClient.getTargetTemperature(
             this.deviceId,
             airstage.constants.TEMPERATURE_SCALE_CELSIUS,
-            function (error, targetTemperature) {
+            (function (error, targetTemperature) {
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error, null);
                 }
 
+                this._logMethodCallResult(methodName, null, targetTemperature);
+
                 callback(null, targetTemperature);
-            }
+            }).bind(this)
         );
     }
 
     setTargetTemperature(value, callback) {
+        const methodName = this.setTargetTemperature.name;
+
+        this._logMethodCall(methodName, value);
+
         this.airstageClient.setTargetTemperature(
             this.deviceId,
             value,
             airstage.constants.TEMPERATURE_SCALE_CELSIUS,
             (function (error) {
                 if (error) {
+                    this._logMethodCallResult(methodName, error);
+
                     return callback(error);
                 }
 
-                this._refreshCurrentCharacteristics();
+                this._logMethodCallResult(methodName, null, null);
 
-                return callback(null);
+                this._refreshDynamicServiceCharacteristics();
+
+                callback(null);
             }).bind(this)
         );
     }
 
     getTemperatureDisplayUnits(callback) {
-        this.airstageClient.getTemperatureScale((function (error, temperatureScale) {
-            let temperatureDisplayUnits = null;
+        const methodName = this.getTemperatureDisplayUnits.name;
 
-            if (error) {
-                return callback(error, null);
-            }
+        this._logMethodCall(methodName);
 
-            if (temperatureScale === airstage.constants.TEMPERATURE_SCALE_CELSIUS) {
-                temperatureDisplayUnits = this.platform.Characteristic.TemperatureDisplayUnits.CELSIUS;
-            } else if (temperatureScale === airstage.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
-                temperatureDisplayUnits = this.platform.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
-            }
+        this.airstageClient.getTemperatureScale(
+            (function (error, temperatureScale) {
+                let temperatureDisplayUnits = null;
 
-            callback(null, temperatureDisplayUnits);
-        }).bind(this));
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (temperatureScale === airstage.constants.TEMPERATURE_SCALE_CELSIUS) {
+                    temperatureDisplayUnits = this.platform.Characteristic.TemperatureDisplayUnits.CELSIUS;
+                } else if (temperatureScale === airstage.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+                    temperatureDisplayUnits = this.platform.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
+                }
+
+                this._logMethodCallResult(methodName, null, temperatureDisplayUnits);
+
+                callback(null, temperatureDisplayUnits);
+            }).bind(this)
+        );
     }
 
     setTemperatureDisplayUnits(value, callback) {
+        const methodName = this.setTemperatureDisplayUnits.name;
+
+        this._logMethodCall(methodName, value);
+
         let scale = null;
 
         if (value === this.platform.Characteristic.TemperatureDisplayUnits.FAHRENHEIT) {
@@ -263,19 +347,43 @@ class ThermostatAccessory {
             temperatureScale = airstage.constants.TEMPERATURE_SCALE_CELSIUS;
         }
 
-        this.airstageClient.setTemperatureScale(scale, function(error) {
-            callback(error);
-        });
+        this.airstageClient.setTemperatureScale(
+            scale,
+            (function(error) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error);
+                }
+
+                this._logMethodCallResult(methodName, null, null);
+
+                callback(null);
+            }).bind(this)
+        );
     }
 
     getName(callback) {
-        this.airstageClient.getName(this.deviceId, function(error, name) {
-            if (error) {
-                return callback(error, null);
-            }
+        const methodName = this.getName.name;
 
-            callback(null, name + ' Thermostat');
-        });
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getName(
+            this.deviceId,
+            (function(error, name) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                const value = name + ' Thermostat';
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
     }
 
     _refreshRelatedAccessoryCharacteristics() {
@@ -284,18 +392,6 @@ class ThermostatAccessory {
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
-    }
-
-    _refreshCurrentCharacteristics() {
-        const accessoryManager = this.platform.accessoryManager;
-
-        accessoryManager.refreshServiceCharacteristics(
-            this.service,
-            [
-                this.platform.Characteristic.CurrentHeatingCoolingState,
-                this.platform.Characteristic.CurrentTemperature
-            ]
-        );
     }
 }
 

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -149,9 +149,7 @@ class ThermostatAccessory {
                         return callback(error);
                     }
 
-                    this._updateFanServiceCharacteristics();
-                    this._updateFanModeSwitchCharacteristics();
-                    this._updateDryModeSwitchCharacteristics();
+                    this._refreshRelatedAccessoryCharacteristics();
 
                     callback(null);
                 }).bind(this)
@@ -182,9 +180,7 @@ class ThermostatAccessory {
                             return callback(error);
                         }
 
-                        this._updateFanServiceCharacteristics();
-                        this._updateFanModeSwitchCharacteristics();
-                        this._updateDryModeSwitchCharacteristics();
+                        this._refreshRelatedAccessoryCharacteristics();
 
                         callback(null);
                     }).bind(this)
@@ -280,145 +276,12 @@ class ThermostatAccessory {
         });
     }
 
-    _updateFanServiceCharacteristics() {
-        const fanService = this._getFanService();
+    _refreshRelatedAccessoryCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
 
-        if (fanService === null) {
-            return false;
-        }
-
-        const active = fanService.getCharacteristic(
-            this.platform.Characteristic.Active
-        );
-        const currentFanState = fanService.getCharacteristic(
-            this.platform.Characteristic.CurrentFanState
-        );
-        const targetFanState = fanService.getCharacteristic(
-            this.platform.Characteristic.TargetFanState
-        );
-        const rotationSpeed = fanService.getCharacteristic(
-            this.platform.Characteristic.RotationSpeed
-        );
-
-        active.emit('get', function(error, value) {
-            if (error === null) {
-                active.sendEventNotification(value);
-            }
-        });
-
-        currentFanState.emit('get', function(error, value) {
-            if (error === null) {
-                currentFanState.sendEventNotification(value);
-            }
-        });
-
-        targetFanState.emit('get', function(error, value) {
-            if (error === null) {
-                targetFanState.sendEventNotification(value);
-            }
-        });
-
-        rotationSpeed.emit('get', function(error, value) {
-            if (error === null) {
-                rotationSpeed.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _updateFanModeSwitchCharacteristics() {
-        const fanModeSwitch = this._getFanModeSwitch();
-
-        if (fanModeSwitch === null) {
-            return false;
-        }
-
-        const on = fanModeSwitch.getCharacteristic(
-            this.platform.Characteristic.On
-        );
-
-        on.emit('get', function(error, value) {
-            if (error === null) {
-                on.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _updateDryModeSwitchCharacteristics() {
-        const dryModeSwitch = this._getDryModeSwitch();
-
-        if (dryModeSwitch === null) {
-            return false;
-        }
-
-        const on = dryModeSwitch.getCharacteristic(
-            this.platform.Characteristic.On
-        );
-
-        on.emit('get', function(error, value) {
-            if (error === null) {
-                on.sendEventNotification(value);
-            }
-        });
-
-        return true;
-    }
-
-    _getFanService() {
-        let fanService = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-fan'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            fanService = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Fanv2
-            );
-        }
-
-        return fanService;
-    }
-
-    _getFanModeSwitch() {
-        let fanModeSwitch = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-fan-mode-switch'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            fanModeSwitch = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Switch
-            );
-        }
-
-        return fanModeSwitch;
-    }
-
-    _getDryModeSwitch() {
-        let dryModeSwitch = null;
-        const uuid = this.platform.api.hap.uuid.generate(
-            this.deviceId + '-dry-mode-switch'
-        );
-        const existingAccessory = this.platform.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            dryModeSwitch = existingAccessory.services.find(
-                service => service instanceof this.platform.Service.Switch
-            );
-        }
-
-        return dryModeSwitch;
+        accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshFanModeSwitchAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
     }
 }
 

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -189,10 +189,10 @@ class ThermostatAccessory extends Accessory {
 
                     this._logMethodCallResult(methodName, null, null);
 
-                    callback(null);
-
                     this._refreshDynamicServiceCharacteristics();
                     this._refreshRelatedAccessoryCharacteristics();
+
+                    callback(null);
                 }).bind(this)
             );
         }
@@ -227,10 +227,10 @@ class ThermostatAccessory extends Accessory {
 
                         this._logMethodCallResult(methodName, null, null);
 
-                        callback(null);
-
                         this._refreshDynamicServiceCharacteristics();
                         this._refreshRelatedAccessoryCharacteristics();
+
+                        callback(null);
                     }).bind(this)
                 );
             }).bind(this)

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -198,12 +198,6 @@ class ThermostatAccessory {
                     return callback(error, null);
                 }
 
-                if (indoorTemperature === null) {
-                    throw new this.platform.api.hap.HapStatusError(
-                        this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
-                    );
-                }
-
                 callback(null, indoorTemperature);
             }
         );

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -150,6 +150,7 @@ class ThermostatAccessory {
                     }
 
                     this._refreshRelatedAccessoryCharacteristics();
+                    this._refreshCurrentCharacteristics();
 
                     callback(null);
                 }).bind(this)
@@ -181,6 +182,7 @@ class ThermostatAccessory {
                         }
 
                         this._refreshRelatedAccessoryCharacteristics();
+                        this._refreshCurrentCharacteristics();
 
                         callback(null);
                     }).bind(this)
@@ -222,9 +224,15 @@ class ThermostatAccessory {
             this.deviceId,
             value,
             airstage.constants.TEMPERATURE_SCALE_CELSIUS,
-            function (error) {
-                callback(error);
-            }
+            (function (error) {
+                if (error) {
+                    return callback(error);
+                }
+
+                this._refreshCurrentCharacteristics();
+
+                return callback(null);
+            }).bind(this)
         );
     }
 
@@ -276,6 +284,18 @@ class ThermostatAccessory {
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
+    }
+
+    _refreshCurrentCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
+
+        accessoryManager.refreshServiceCharacteristics(
+            this.service,
+            [
+                this.platform.Characteristic.CurrentHeatingCoolingState,
+                this.platform.Characteristic.CurrentTemperature
+            ]
+        );
     }
 }
 

--- a/src/airstage/client.js
+++ b/src/airstage/client.js
@@ -32,7 +32,7 @@ class Client {
         );
 
         this.resetUserCache();
-        this.resetDeviceCache(null);
+        this.resetDeviceCache();
     }
 
     refreshTokenOrAuthenticate(callback) {
@@ -835,7 +835,7 @@ class Client {
         this._userMetadataCache = {};
     }
 
-    resetDeviceCache(deviceId) {
+    resetDeviceCache(deviceId = null) {
         if (deviceId === null) {
             this._deviceMetadataCache = {};
             this._deviceParameterCache = {};
@@ -911,11 +911,13 @@ class Client {
             this._deviceMetadataCache[deviceId] = {};
         }
 
-        apiv1.constants.METADATA_KEYS.forEach((function(key) {
-            if (key in device) {
-                this._deviceMetadataCache[deviceId][key] = device[key];
-            }
-        }.bind(this)));
+        if (device) {
+            apiv1.constants.METADATA_KEYS.forEach((function(key) {
+                if (key in device) {
+                    this._deviceMetadataCache[deviceId][key] = device[key];
+                }
+            }.bind(this)));
+        }
 
         return this._getDeviceMetadataCache(deviceId);
     }
@@ -937,7 +939,7 @@ class Client {
             this._deviceParameterCache[deviceId] = {};
         }
 
-        if ('parameters' in device) {
+        if (device && 'parameters' in device) {
             device.parameters.forEach(function(parameter) {
                 let parameterName = null;
                 let parameterValue = null;
@@ -974,16 +976,14 @@ class Client {
                 if (result.response.status === apiv1.constants.PARAMETER_STATUS_WAITING) {
                     this._pollRequestStatus(deviceId, requestId, callback);
                 } else {
-                    if (result.response.result === apiv1.constants.PARAMETER_RESULT_SUCCESS) {
-                        deviceMetadata = this._setDeviceMetadataCache(
-                            deviceId,
-                            result.response
-                        );
-                        deviceParameters = this._setDeviceParameterCache(
-                            deviceId,
-                            result.response
-                        );
-                    }
+                    deviceMetadata = this._setDeviceMetadataCache(
+                        deviceId,
+                        result.response
+                    );
+                    deviceParameters = this._setDeviceParameterCache(
+                        deviceId,
+                        result.response
+                    );
 
                     callback(null, {
                         'metadata': deviceMetadata,

--- a/src/airstage/client.js
+++ b/src/airstage/client.js
@@ -912,11 +912,11 @@ class Client {
         }
 
         if (device) {
-            apiv1.constants.METADATA_KEYS.forEach((function(key) {
+            apiv1.constants.METADATA_KEYS.forEach(function(key) {
                 if (key in device) {
                     this._deviceMetadataCache[deviceId][key] = device[key];
                 }
-            }.bind(this)));
+            }, this);
         }
 
         return this._getDeviceMetadataCache(deviceId);

--- a/src/airstage/client.js
+++ b/src/airstage/client.js
@@ -363,10 +363,6 @@ class Client {
                 return callback(error, null);
             }
 
-            if (indoorTemperature === null) {
-                return callback('Indoor temperature not available', null);
-            }
-
             this.getTargetTemperature(deviceId, scale, (function(error, targetTemperature) {
                 let temperatureDelta = null;
 
@@ -651,6 +647,10 @@ class Client {
 
             if (device.parameters) {
                 result = device.parameters[name];
+            }
+
+            if (result === null) {
+                return callback('Parameter not available: ' + name, null);
             }
 
             callback(null, result);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Accessory suffixes
+module.exports.ACCESSORY_SUFFIX_THERMOSTAT = 'thermostat';
+module.exports.ACCESSORY_SUFFIX_FAN = 'fan';
+module.exports.ACCESSORY_SUFFIX_VERTICAL_SLATS = 'vertical-slats';
+module.exports.ACCESSORY_SUFFIX_DRY_MODE_SWITCH = 'dry-mode-switch';
+module.exports.ACCESSORY_SUFFIX_FAN_MODE_SWITCH = 'fan-mode-switch';
+module.exports.ACCESSORY_SUFFIX_ECONOMY_SWITCH = 'economy-switch';
+module.exports.ACCESSORY_SUFFIX_ENERGY_SAVING_FAN_SWITCH = 'energy-saving-fan-switch';
+module.exports.ACCESSORY_SUFFIX_POWERFUL_SWITCH = 'powerful-switch';

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -1,0 +1,345 @@
+'use strict';
+
+const accessories = require('./accessories');
+const constants = require('./constants');
+const settings = require('./settings');
+
+class PlatformAccessoryManager {
+
+    constructor(platform) {
+        this.platform = platform;
+    }
+
+    registerThermostatAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_THERMOSTAT;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.ThermostatAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.ThermostatAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    registerFanAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_FAN;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.FanAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.FanAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    registerVerticalSlatsAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_VERTICAL_SLATS;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.VerticalSlatsAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.VerticalSlatsAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    registerDryModeSwitchAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.DryModeSwitchAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.DryModeSwitchAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    registerFanModeSwitchAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_FAN_MODE_SWITCH;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.FanModeSwitchAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.FanModeSwitchAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    registerEconomySwitchAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_ECONOMY_SWITCH;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.EconomySwitchAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.EconomySwitchAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    registerEnergySavingFanSwitchAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_ENERGY_SAVING_FAN_SWITCH;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.EnergySavingFanSwitchAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.EnergySavingFanSwitchAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    registerPowerfulSwitchAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_POWERFUL_SWITCH;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.PowerfulSwitchAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.PowerfulSwitchAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
+    refreshThermostatAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_THERMOSTAT;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.CurrentHeatingCoolingState,
+                this.platform.Characteristic.TargetHeatingCoolingState
+            ]
+        );
+    }
+
+    refreshFanAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_FAN;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.Active,
+                this.platform.Characteristic.CurrentFanState,
+                this.platform.Characteristic.TargetFanState,
+                this.platform.Characteristic.RotationSpeed
+            ]
+        );
+    }
+
+    refreshDryModeSwitchAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.On
+            ]
+        );
+    }
+
+    refreshFanModeSwitchAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_FAN_MODE_SWITCH;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.On
+            ]
+        );
+    }
+
+    _updateExistingAccessory(existingAccessory, deviceId, model) {
+        this.platform.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
+
+        existingAccessory.context.airstageClient = this.platform.airstageClient;
+        existingAccessory.context.deviceId = deviceId;
+        existingAccessory.context.model = model;
+
+        this.platform.api.updatePlatformAccessories([existingAccessory]);
+    }
+
+    _registerNewAccessory(newAccessory, deviceId, model) {
+        this.platform.log.info('Adding new accessory:', newAccessory.displayName);
+
+        newAccessory.context.airstageClient = this.platform.airstageClient;
+        newAccessory.context.deviceId = deviceId;
+        newAccessory.context.model = model;
+
+        this.platform.api.registerPlatformAccessories(
+            settings.PLUGIN_NAME,
+            settings.PLATFORM_NAME,
+            [newAccessory]
+        );
+
+        this.platform.accessories.push(newAccessory);
+    }
+
+    _instantiateNewAccessory(deviceId, deviceName, model, suffix) {
+        const accessoryName = this._getAccessoryName(deviceName, suffix);
+        const accessoryUuid = this._getAccessoryUuid(deviceId, suffix);
+        const accessory = new this.platform.api.platformAccessory(
+            accessoryName,
+            accessoryUuid
+        );
+
+        accessory.context.airstageClient = this.platform.airstageClient;
+        accessory.context.deviceId = deviceId;
+        accessory.context.model = model;
+
+        return accessory;
+    }
+
+    _getExistingAccessory(deviceId, suffix) {
+        const accessoryUuid = this._getAccessoryUuid(deviceId, suffix);
+
+        return this.platform.accessories.find(
+            accessory => accessory.UUID === accessoryUuid
+        ) || null;
+    }
+
+    _refreshAccessoryCharacteristics(accessory, characteristicClasses) {
+        const service = accessory.services.find(
+            service => (service instanceof this.platform.Service.AccessoryInformation) === false
+        ) || null;
+
+        if (service === null) {
+            return false;
+        }
+
+        characteristicClasses.forEach(function(characteristicClass) {
+            const characteristic = service.getCharacteristic(characteristicClass);
+
+            characteristic.emit('get', function(error, value) {
+                if (error === null) {
+                    characteristic.sendEventNotification(value);
+                }
+            });
+        });
+
+        return true;
+    }
+
+    _getAccessoryName(deviceName, suffix) {
+        const suffixParts = suffix.split('-');
+
+        suffixParts.forEach(function(part, idx, array) {
+            array[idx] = (part.charAt(0).toUpperCase() + part.substring(1));
+        });
+
+        return deviceName + ' ' + suffixParts.join(' ');
+    }
+
+    _getAccessoryUuid(deviceId, suffix) {
+        return this.platform.api.hap.uuid.generate(
+            deviceId + '-' + suffix
+        );
+    }
+}
+
+module.exports = PlatformAccessoryManager;

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -385,23 +385,21 @@ class PlatformAccessoryManager {
     }
 
     refreshServiceCharacteristics(service, characteristicClasses) {
-        characteristicClasses.forEach(
-            (function(characteristicClass) {
-                const characteristic = service.getCharacteristic(characteristicClass);
-                let logMessage = '[' + service.constructor.name + '][' + characteristic.constructor.name + '] Refreshing characteristic';
+        characteristicClasses.forEach(function(characteristicClass) {
+            const characteristic = service.getCharacteristic(characteristicClass);
+            let logMessage = '[' + service.constructor.name + '][' + characteristic.constructor.name + '] Refreshing characteristic';
 
-                this.platform.log.debug(logMessage);
+            this.platform.log.debug(logMessage);
 
-                characteristic.emit('get', function(error, value) {
-                    if (error === null) {
-                        characteristic.sendEventNotification(value);
-                    } else {
-                        logMessage = logMessage + ' failed with error: ' + error;
-                        this.platform.log.error(logMessage);
-                    }
-                });
-            }).bind(this)
-        );
+            characteristic.emit('get', function(error, value) {
+                if (error === null) {
+                    characteristic.sendEventNotification(value);
+                } else {
+                    logMessage = logMessage + ' failed with error: ' + error;
+                    this.platform.log.error(logMessage);
+                }
+            });
+        }, this);
 
         return true;
     }

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -98,28 +98,6 @@ class PlatformAccessoryManager {
         }
     }
 
-    registerFanModeSwitchAccessory(deviceId, deviceName, model) {
-        const suffix = constants.ACCESSORY_SUFFIX_FAN_MODE_SWITCH;
-        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
-
-        if (existingAccessory) {
-            this._updateExistingAccessory(existingAccessory, deviceId, model);
-
-            new accessories.FanModeSwitchAccessory(this.platform, existingAccessory);
-        } else {
-            const newAccessory = this._instantiateNewAccessory(
-                deviceId,
-                deviceName,
-                model,
-                suffix
-            );
-
-            new accessories.FanModeSwitchAccessory(this.platform, newAccessory);
-
-            this._registerNewAccessory(newAccessory, deviceId, model);
-        }
-    }
-
     registerEconomySwitchAccessory(deviceId, deviceName, model) {
         const suffix = constants.ACCESSORY_SUFFIX_ECONOMY_SWITCH;
         const existingAccessory = this._getExistingAccessory(deviceId, suffix);
@@ -164,6 +142,28 @@ class PlatformAccessoryManager {
         }
     }
 
+    registerFanModeSwitchAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_FAN_MODE_SWITCH;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.FanModeSwitchAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.FanModeSwitchAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
     registerPowerfulSwitchAccessory(deviceId, deviceName, model) {
         const suffix = constants.ACCESSORY_SUFFIX_POWERFUL_SWITCH;
         const existingAccessory = this._getExistingAccessory(deviceId, suffix);
@@ -186,6 +186,65 @@ class PlatformAccessoryManager {
         }
     }
 
+    unregisterThermostatAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_THERMOSTAT;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    unregisterFanAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_FAN;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    unregisterVerticalSlatsAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_VERTICAL_SLATS;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    unregisterDryModeSwitchAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    unregisterEconomySwitchAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_ECONOMY_SWITCH;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    unregisterEnergySavingFanSwitchAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_ENERGY_SAVING_FAN_SWITCH;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    unregisterFanModeSwitchAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_FAN_MODE_SWITCH;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    unregisterPowerfulSwitchAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_POWERFUL_SWITCH;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
+    refreshAllAccessoryCharacteristics(deviceId) {
+        this.refreshThermostatAccessoryCharacteristics(deviceId);
+        this.refreshFanAccessoryCharacteristics(deviceId);
+        this.refreshVerticalSlatsAccessoryCharacteristics(deviceId);
+        this.refreshDryModeSwitchAccessoryCharacteristics(deviceId);
+        this.refreshEconomySwitchAccessoryCharacteristics(deviceId);
+        this.refreshEnergySavingFanSwitchAccessoryCharacteristics(deviceId);
+        this.refreshFanModeSwitchAccessoryCharacteristics(deviceId);
+        this.refreshPowerfulSwitchAccessoryCharacteristics(deviceId);
+    }
+
     refreshThermostatAccessoryCharacteristics(deviceId) {
         const suffix = constants.ACCESSORY_SUFFIX_THERMOSTAT;
         const accessory = this._getExistingAccessory(deviceId, suffix);
@@ -198,7 +257,10 @@ class PlatformAccessoryManager {
             accessory,
             [
                 this.platform.Characteristic.CurrentHeatingCoolingState,
-                this.platform.Characteristic.TargetHeatingCoolingState
+                this.platform.Characteristic.TargetHeatingCoolingState,
+                this.platform.Characteristic.CurrentTemperature,
+                this.platform.Characteristic.TargetTemperature,
+                this.platform.Characteristic.TemperatureDisplayUnits
             ]
         );
     }
@@ -217,13 +279,65 @@ class PlatformAccessoryManager {
                 this.platform.Characteristic.Active,
                 this.platform.Characteristic.CurrentFanState,
                 this.platform.Characteristic.TargetFanState,
-                this.platform.Characteristic.RotationSpeed
+                this.platform.Characteristic.RotationSpeed,
+                this.platform.Characteristic.SwingMode
+            ]
+        );
+    }
+
+    refreshVerticalSlatsAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_VERTICAL_SLATS;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.CurrentSlatState,
+                this.platform.Characteristic.SwingMode,
+                this.platform.Characteristic.CurrentTiltAngle,
+                this.platform.Characteristic.TargetTiltAngle
             ]
         );
     }
 
     refreshDryModeSwitchAccessoryCharacteristics(deviceId) {
         const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.On
+            ]
+        );
+    }
+
+    refreshEconomySwitchAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_ECONOMY_SWITCH;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.On
+            ]
+        );
+    }
+
+    refreshEnergySavingFanSwitchAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_ENERGY_SAVING_FAN_SWITCH;
         const accessory = this._getExistingAccessory(deviceId, suffix);
 
         if (accessory === null) {
@@ -254,16 +368,40 @@ class PlatformAccessoryManager {
         );
     }
 
-    refreshServiceCharacteristics(service, characteristicClasses) {
-        characteristicClasses.forEach(function(characteristicClass) {
-            const characteristic = service.getCharacteristic(characteristicClass);
+    refreshPowerfulSwitchAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_POWERFUL_SWITCH;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
 
-            characteristic.emit('get', function(error, value) {
-                if (error === null) {
-                    characteristic.sendEventNotification(value);
-                }
-            });
-        });
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.platform.Characteristic.On
+            ]
+        );
+    }
+
+    refreshServiceCharacteristics(service, characteristicClasses) {
+        characteristicClasses.forEach(
+            (function(characteristicClass) {
+                const characteristic = service.getCharacteristic(characteristicClass);
+                let logMessage = '[' + service.constructor.name + '][' + characteristic.constructor.name + '] Refreshing characteristic';
+
+                this.platform.log.debug(logMessage);
+
+                characteristic.emit('get', function(error, value) {
+                    if (error === null) {
+                        characteristic.sendEventNotification(value);
+                    } else {
+                        logMessage = logMessage + ' failed with error: ' + error;
+                        this.platform.log.error(logMessage);
+                    }
+                });
+            }).bind(this)
+        );
 
         return true;
     }
@@ -276,6 +414,30 @@ class PlatformAccessoryManager {
         existingAccessory.context.model = model;
 
         this.platform.api.updatePlatformAccessories([existingAccessory]);
+    }
+
+    _unregisterAccessory(deviceId, deviceName, suffix) {
+        const accessoryName = this._getAccessoryName(deviceName, suffix);
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        this.platform.log.info(
+            'Not adding accessory because it is disabled in the config:',
+            accessoryName
+        );
+
+        if (existingAccessory) {
+            this._unregisterExistingAccessory(existingAccessory);
+        }
+    }
+
+    _unregisterExistingAccessory(existingAccessory) {
+        this.platform.log.info('Removing existing accessory from cache:', existingAccessory.displayName);
+
+        this.platform.api.unregisterPlatformAccessories(
+            settings.PLUGIN_NAME,
+            settings.PLATFORM_NAME,
+            [existingAccessory]
+        );
     }
 
     _registerNewAccessory(newAccessory, deviceId, model) {

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -254,6 +254,20 @@ class PlatformAccessoryManager {
         );
     }
 
+    refreshServiceCharacteristics(service, characteristicClasses) {
+        characteristicClasses.forEach(function(characteristicClass) {
+            const characteristic = service.getCharacteristic(characteristicClass);
+
+            characteristic.emit('get', function(error, value) {
+                if (error === null) {
+                    characteristic.sendEventNotification(value);
+                }
+            });
+        });
+
+        return true;
+    }
+
     _updateExistingAccessory(existingAccessory, deviceId, model) {
         this.platform.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
 
@@ -312,17 +326,10 @@ class PlatformAccessoryManager {
             return false;
         }
 
-        characteristicClasses.forEach(function(characteristicClass) {
-            const characteristic = service.getCharacteristic(characteristicClass);
-
-            characteristic.emit('get', function(error, value) {
-                if (error === null) {
-                    characteristic.sendEventNotification(value);
-                }
-            });
-        });
-
-        return true;
+        return this.refreshServiceCharacteristics(
+            service,
+            characteristicClasses
+        );
     }
 
     _getAccessoryName(deviceName, suffix) {

--- a/src/platform.js
+++ b/src/platform.js
@@ -172,9 +172,7 @@ class Platform {
     _refreshAirstageClientToken() {
         this.airstageClient.refreshToken((function(error) {
             if (error) {
-                throw new this.api.hap.HapStatusError(
-                    this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
-                );
+                return this.log.error('Error when attempting to refresh Airbridge access token:', error);
             }
 
             this._updateConfigWithAccessToken();
@@ -190,9 +188,7 @@ class Platform {
         this.airstageClient.getUserMetadata(
             (function(error) {
                 if (error) {
-                    throw new this.api.hap.HapStatusError(
-                        this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
-                    );
+                    return this.log.error('Error when attempting to communicate with Airbridge:', error);
                 }
 
                 this.log.debug('Refreshed Airstage client user metadata cache');
@@ -204,9 +200,7 @@ class Platform {
             limit,
             (function(error) {
                 if (error) {
-                    throw new this.api.hap.HapStatusError(
-                        this.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE
-                    );
+                    return this.log.error('Error when attempting to communicate with Airbridge:', error);
                 }
 
                 this.log.debug('Refreshed Airstage client device cache');

--- a/src/platform.js
+++ b/src/platform.js
@@ -71,82 +71,26 @@ class Platform {
                     return this.log.error('Error when attempting to communicate with Airbridge:', error);
                 }
 
-                this.airstageClient.getDevices(null, (function(error, result) {
+                this.airstageClient.getDevices(null, (function(error, devices) {
                     if (error) {
                         return this.log.error('Error when attempting to communicate with Airbridge:', error);
                     }
 
-                    const deviceIds = Object.keys(result.metadata);
+                    const deviceIds = Object.keys(devices.metadata);
 
                     deviceIds.forEach((function(deviceId) {
-                        const deviceMetadata = result.metadata[deviceId];
-                        const deviceParameters = result.parameters[deviceId];
+                        const deviceMetadata = devices.metadata[deviceId];
+                        const deviceParameters = devices.parameters[deviceId];
                         const deviceName = deviceMetadata.deviceName;
                         const model = deviceParameters[airstage.apiv1.constants.PARAMETER_MODEL];
 
-                        if (this.config.enableThermostat) {
-                            this.accessoryManager.registerThermostatAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
-
-                        if (this.config.enableFan) {
-                            this.accessoryManager.registerFanAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
-
-                        if (this.config.enableVerticalSlats) {
-                            this.accessoryManager.registerVerticalSlatsAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
-
-                        if (this.config.enableDryModeSwitch) {
-                            this.accessoryManager.registerDryModeSwitchAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
-
-                        if (this.config.enableEconomySwitch) {
-                            this.accessoryManager.registerEconomySwitchAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
-
-                        if (this.config.enableEnergySavingFanSwitch) {
-                            this.accessoryManager.registerEnergySavingFanSwitchAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
-
-                        if (this.config.enableFanModeSwitch) {
-                            this.accessoryManager.registerFanModeSwitchAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
-
-                        if (this.config.enablePowerfulSwitch) {
-                            this.accessoryManager.registerPowerfulSwitchAccessory(
-                                deviceId,
-                                deviceName,
-                                model
-                            );
-                        }
+                        this._configureAirstageDevice(
+                            deviceId,
+                            deviceMetadata,
+                            deviceParameters,
+                            deviceName,
+                            model
+                        );
                     }).bind(this));
                 }).bind(this));
             }).bind(this));
@@ -166,6 +110,118 @@ class Platform {
             );
 
             this.log.debug('Updated config with Airstage client token');
+        }
+    }
+
+    _configureAirstageDevice(
+        deviceId,
+        deviceMetadata,
+        deviceParameters,
+        deviceName,
+        model
+    ) {
+        if (this.config.enableThermostat) {
+            this.accessoryManager.registerThermostatAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterThermostatAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
+        if (this.config.enableFan) {
+            this.accessoryManager.registerFanAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterFanAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
+        if (this.config.enableVerticalSlats) {
+            this.accessoryManager.registerVerticalSlatsAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterVerticalSlatsAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
+        if (this.config.enableDryModeSwitch) {
+            this.accessoryManager.registerDryModeSwitchAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterDryModeSwitchAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
+        if (this.config.enableEconomySwitch) {
+            this.accessoryManager.registerEconomySwitchAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterEconomySwitchAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
+        if (this.config.enableEnergySavingFanSwitch) {
+            this.accessoryManager.registerEnergySavingFanSwitchAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterEnergySavingFanSwitchAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
+        if (this.config.enableFanModeSwitch) {
+            this.accessoryManager.registerFanModeSwitchAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterFanModeSwitchAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
+        if (this.config.enablePowerfulSwitch) {
+            this.accessoryManager.registerPowerfulSwitchAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterPowerfulSwitchAccessory(
+                deviceId,
+                deviceName
+            );
         }
     }
 
@@ -192,18 +248,24 @@ class Platform {
                 }
 
                 this.log.debug('Refreshed Airstage client user metadata cache');
-            }).bind(this)
-        );
 
-        this.airstageClient.resetDeviceCache();
-        this.airstageClient.getDevices(
-            limit,
-            (function(error) {
-                if (error) {
-                    return this.log.error('Error when attempting to communicate with Airbridge:', error);
-                }
+                this.airstageClient.resetDeviceCache();
+                this.airstageClient.getDevices(
+                    limit,
+                    (function(error, devices) {
+                        if (error) {
+                            return this.log.error('Error when attempting to communicate with Airbridge:', error);
+                        }
 
-                this.log.debug('Refreshed Airstage client device cache');
+                        this.log.debug('Refreshed Airstage client device cache');
+
+                        const deviceIds = Object.keys(devices.metadata);
+
+                        deviceIds.forEach((function(deviceId) {
+                            this.accessoryManager.refreshAllAccessoryCharacteristics(deviceId);
+                        }).bind(this));
+                    }).bind(this)
+                );
             }).bind(this)
         );
     }

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ConfigManager = require('./config-manager');
+const PlatformAccessoryManager = require('./platform-accessory-manager');
 const accessories = require('./accessories');
 const airstage = require('./airstage');
 const settings = require('./settings');
@@ -36,6 +37,7 @@ class Platform {
         );
 
         this.configManager = new ConfigManager(this.config, this.api);
+        this.accessoryManager = new PlatformAccessoryManager(this);
 
         setInterval(
             this._refreshAirstageClientCache.bind(this),
@@ -83,35 +85,67 @@ class Platform {
                         const model = deviceParameters[airstage.apiv1.constants.PARAMETER_MODEL];
 
                         if (this.config.enableThermostat) {
-                            this._registerThermostat(deviceId, deviceName, model);
+                            this.accessoryManager.registerThermostatAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
 
                         if (this.config.enableFan) {
-                            this._registerFan(deviceId, deviceName, model);
+                            this.accessoryManager.registerFanAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
 
                         if (this.config.enableVerticalSlats) {
-                            this._registerVerticalSlatsAccessory(deviceId, deviceName, model);
+                            this.accessoryManager.registerVerticalSlatsAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
 
                         if (this.config.enableDryModeSwitch) {
-                            this._registerDryModeSwitch(deviceId, deviceName, model);
+                            this.accessoryManager.registerDryModeSwitchAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
 
                         if (this.config.enableEconomySwitch) {
-                            this._registerEconomySwitch(deviceId, deviceName, model);
+                            this.accessoryManager.registerEconomySwitchAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
 
                         if (this.config.enableEnergySavingFanSwitch) {
-                            this._registerEnergySavingFanSwitch(deviceId, deviceName, model);
+                            this.accessoryManager.registerEnergySavingFanSwitchAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
 
                         if (this.config.enableFanModeSwitch) {
-                            this._registerFanModeSwitch(deviceId, deviceName, model);
+                            this.accessoryManager.registerFanModeSwitchAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
 
                         if (this.config.enablePowerfulSwitch) {
-                            this._registerPowerfulSwitch(deviceId, deviceName, model);
+                            this.accessoryManager.registerPowerfulSwitchAccessory(
+                                deviceId,
+                                deviceName,
+                                model
+                            );
                         }
                     }).bind(this));
                 }).bind(this));
@@ -132,310 +166,6 @@ class Platform {
             );
 
             this.log.debug('Updated config with Airstage client token');
-        }
-    }
-
-    _registerThermostat(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-thermostat');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.ThermostatAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Thermostat',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.ThermostatAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
-        }
-    }
-
-    _registerFan(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-fan');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.FanAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Fan',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.FanAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
-        }
-    }
-
-    _registerVerticalSlatsAccessory(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-vertical-slats');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.VerticalSlatsAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Vertical Slats',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.VerticalSlatsAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
-        }
-    }
-
-    _registerDryModeSwitch(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-dry-mode-switch');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.DryModeSwitchAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Dry Mode Switch',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.DryModeSwitchAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
-        }
-    }
-
-    _registerEconomySwitch(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-economy-switch');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.EconomySwitchAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Economy Switch',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.EconomySwitchAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
-        }
-    }
-
-    _registerEnergySavingFanSwitch(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-energy-saving-fan-switch');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.EnergySavingFanSwitchAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Energy Saving Fan Switch',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.EnergySavingFanSwitchAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
-        }
-    }
-
-    _registerFanModeSwitch(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-fan-mode-switch');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.FanModeSwitchAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Fan Mode Switch',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.FanModeSwitchAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
-        }
-    }
-
-    _registerPowerfulSwitch(deviceId, deviceName, model) {
-        const uuid = this.api.hap.uuid.generate(deviceId + '-powerful-switch');
-        const existingAccessory = this.accessories.find(
-            accessory => accessory.UUID === uuid
-        );
-
-        if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.airstageClient = this.airstageClient;
-            existingAccessory.context.deviceId = deviceId;
-            existingAccessory.context.model = model;
-
-            this.api.updatePlatformAccessories([existingAccessory]);
-
-            new accessories.PowerfulSwitchAccessory(this, existingAccessory);
-        } else {
-            const accessory = new this.api.platformAccessory(
-                deviceName + ' Powerful Switch',
-                uuid
-            );
-
-            this.log.info('Adding new accessory:', accessory.displayName);
-
-            accessory.context.airstageClient = this.airstageClient;
-            accessory.context.deviceId = deviceId;
-            accessory.context.model = model;
-
-            new accessories.PowerfulSwitchAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(
-                settings.PLUGIN_NAME,
-                settings.PLATFORM_NAME,
-                [accessory]
-            );
         }
     }
 

--- a/src/platform.js
+++ b/src/platform.js
@@ -78,7 +78,7 @@ class Platform {
 
                     const deviceIds = Object.keys(devices.metadata);
 
-                    deviceIds.forEach((function(deviceId) {
+                    deviceIds.forEach(function(deviceId) {
                         const deviceMetadata = devices.metadata[deviceId];
                         const deviceParameters = devices.parameters[deviceId];
                         const deviceName = deviceMetadata.deviceName;
@@ -91,7 +91,7 @@ class Platform {
                             deviceName,
                             model
                         );
-                    }).bind(this));
+                    }, this);
                 }).bind(this));
             }).bind(this));
         }).bind(this));
@@ -261,9 +261,9 @@ class Platform {
 
                         const deviceIds = Object.keys(devices.metadata);
 
-                        deviceIds.forEach((function(deviceId) {
+                        deviceIds.forEach(function(deviceId) {
                             this.accessoryManager.refreshAllAccessoryCharacteristics(deviceId);
-                        }).bind(this));
+                        }, this);
                     }).bind(this)
                 );
             }).bind(this)

--- a/test/airstage/test-client.js
+++ b/test/airstage/test-client.js
@@ -1889,3 +1889,36 @@ test('airstage.Client#getRefreshToken returns access token', (context) => {
 
     assert.strictEqual(refreshToken, 'existingRefreshToken');
 });
+
+test('airstage.Client#getParameter calls _apiClient.getDevice with "Parameter not available" error', (context, done) => {
+    const expectedResponse = {
+        'parameters': [
+            {
+                'name': 'iu_indoor_tmp',
+                'value': '65535'
+            }
+        ]
+    };
+    context.mock.method(
+        clientWithAccessToken._apiClient,
+        'getDevice',
+        (deviceId, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithAccessToken._apiClient.getDevice.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 2);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '12345');
+    });
+    clientWithAccessToken.resetDeviceCache('12345');
+
+    clientWithAccessToken.getParameter('12345', 'iu_indoor_tmp', (error, result) => {
+        assert.strictEqual(error, 'Parameter not available: iu_indoor_tmp');
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});


### PR DESCRIPTION
- Add and use `PlatformAccessoryManager` for registering, unregistering, and refreshing characteristics on platform accessories
- Add and use base `Accessory` class in platform accessory classes
- Fix cacheing in Airstage client
- Use error logs instead of throwing `HapStatusError` on Airstage client errors