### PR TITLE
Validate the region, update tests, clean up code

### DIFF
--- a/src/accessories/accessory.js
+++ b/src/accessories/accessory.js
@@ -9,13 +9,16 @@ class Accessory {
         this.accessory = accessory;
         this.dynamicServiceCharacteristics = [];
 
+        this.Service = this.platform.Service;
+        this.Characteristic = this.platform.Characteristic;
+
         this.deviceId = this.accessory.context.deviceId;
         this.airstageClient = this.accessory.context.airstageClient;
 
-        this.accessory.getService(this.platform.Service.AccessoryInformation)
-            .setCharacteristic(this.platform.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
-            .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.deviceId);
+        this.accessory.getService(this.Service.AccessoryInformation)
+            .setCharacteristic(this.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
+            .setCharacteristic(this.Characteristic.Model, this.accessory.context.model)
+            .setCharacteristic(this.Characteristic.SerialNumber, this.accessory.context.deviceId);
     }
 
     _refreshDynamicServiceCharacteristics() {

--- a/src/accessories/dry-mode-switch-accessory.js
+++ b/src/accessories/dry-mode-switch-accessory.js
@@ -11,15 +11,15 @@ class DryModeSwitchAccessory extends Accessory {
         this.lastKnownOperationMode = null;
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Switch) ||
-            this.accessory.addService(this.platform.Service.Switch)
+            this.accessory.getService(this.Service.Switch) ||
+            this.accessory.addService(this.Service.Switch)
         );
 
-        this.service.getCharacteristic(this.platform.Characteristic.On)
+        this.service.getCharacteristic(this.Characteristic.On)
             .on('get', this.getOn.bind(this))
             .on('set', this.setOn.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
     }
 

--- a/src/accessories/economy-switch-accessory.js
+++ b/src/accessories/economy-switch-accessory.js
@@ -9,15 +9,15 @@ class EconomySwitchAccessory extends Accessory {
         super(platform, accessory);
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Switch) ||
-            this.accessory.addService(this.platform.Service.Switch)
+            this.accessory.getService(this.Service.Switch) ||
+            this.accessory.addService(this.Service.Switch)
         );
 
-        this.service.getCharacteristic(this.platform.Characteristic.On)
+        this.service.getCharacteristic(this.Characteristic.On)
             .on('get', this.getOn.bind(this))
             .on('set', this.setOn.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
     }
 

--- a/src/accessories/energy-saving-fan-switch-accessory.js
+++ b/src/accessories/energy-saving-fan-switch-accessory.js
@@ -9,15 +9,15 @@ class EnergySavingFanSwitchAccessory extends Accessory {
         super(platform, accessory);
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Switch) ||
-            this.accessory.addService(this.platform.Service.Switch)
+            this.accessory.getService(this.Service.Switch) ||
+            this.accessory.addService(this.Service.Switch)
         );
 
-        this.service.getCharacteristic(this.platform.Characteristic.On)
+        this.service.getCharacteristic(this.Characteristic.On)
             .on('get', this.getOn.bind(this))
             .on('set', this.setOn.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
     }
 

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -9,33 +9,33 @@ class FanAccessory extends Accessory {
         super(platform, accessory);
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Fanv2) ||
-            this.accessory.addService(this.platform.Service.Fanv2)
+            this.accessory.getService(this.Service.Fanv2) ||
+            this.accessory.addService(this.Service.Fanv2)
         );
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.Active);
-        this.service.getCharacteristic(this.platform.Characteristic.Active)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.Active);
+        this.service.getCharacteristic(this.Characteristic.Active)
             .on('get', this.getActive.bind(this))
             .on('set', this.setActive.bind(this));
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.CurrentFanState);
-        this.service.getCharacteristic(this.platform.Characteristic.CurrentFanState)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.CurrentFanState);
+        this.service.getCharacteristic(this.Characteristic.CurrentFanState)
             .on('get', this.getCurrentFanState.bind(this));
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.TargetFanState);
-        this.service.getCharacteristic(this.platform.Characteristic.TargetFanState)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.TargetFanState);
+        this.service.getCharacteristic(this.Characteristic.TargetFanState)
             .on('get', this.getTargetFanState.bind(this))
             .on('set', this.setTargetFanState.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.RotationSpeed);
-        this.service.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.RotationSpeed);
+        this.service.getCharacteristic(this.Characteristic.RotationSpeed)
             .on('get', this.getRotationSpeed.bind(this))
             .on('set', this.setRotationSpeed.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
+        this.service.getCharacteristic(this.Characteristic.SwingMode)
             .on('get', this.getSwingMode.bind(this))
             .on('set', this.setSwingMode.bind(this));
 
@@ -59,9 +59,9 @@ class FanAccessory extends Accessory {
                 }
 
                 if (powerState === airstage.constants.TOGGLE_ON) {
-                    value = this.platform.Characteristic.Active.ACTIVE;
+                    value = this.Characteristic.Active.ACTIVE;
                 } else if (powerState === airstage.constants.TOGGLE_OFF) {
-                    value = this.platform.Characteristic.Active.INACTIVE;
+                    value = this.Characteristic.Active.INACTIVE;
                 }
 
                 this._logMethodCallResult(methodName, null, value);
@@ -78,9 +78,9 @@ class FanAccessory extends Accessory {
 
         let powerState = null;
 
-        if (value === this.platform.Characteristic.Active.ACTIVE) {
+        if (value === this.Characteristic.Active.ACTIVE) {
             powerState = airstage.constants.TOGGLE_ON;
-        } else if (value === this.platform.Characteristic.Active.INACTIVE) {
+        } else if (value === this.Characteristic.Active.INACTIVE) {
             powerState = airstage.constants.TOGGLE_OFF;
         }
 
@@ -121,9 +121,9 @@ class FanAccessory extends Accessory {
                 }
 
                 if (powerState === airstage.constants.TOGGLE_ON) {
-                    value = this.platform.Characteristic.CurrentFanState.BLOWING_AIR;
+                    value = this.Characteristic.CurrentFanState.BLOWING_AIR;
                 } else if (powerState === airstage.constants.TOGGLE_OFF) {
-                    value = this.platform.Characteristic.CurrentFanState.INACTIVE;
+                    value = this.Characteristic.CurrentFanState.INACTIVE;
                 }
 
                 this._logMethodCallResult(methodName, null, value);
@@ -141,7 +141,7 @@ class FanAccessory extends Accessory {
         this.airstageClient.getFanSpeed(
             this.deviceId,
             (function(error, fanSpeed) {
-                let value = this.platform.Characteristic.TargetFanState.MANUAL;
+                let value = this.Characteristic.TargetFanState.MANUAL;
 
                 if (error) {
                     this._logMethodCallResult(methodName, error);
@@ -150,7 +150,7 @@ class FanAccessory extends Accessory {
                 }
 
                 if (fanSpeed === airstage.constants.FAN_SPEED_AUTO) {
-                    value = this.platform.Characteristic.TargetFanState.AUTO;
+                    value = this.Characteristic.TargetFanState.AUTO;
                 }
 
                 this._logMethodCallResult(methodName, null, value);
@@ -165,7 +165,7 @@ class FanAccessory extends Accessory {
 
         this._logMethodCall(methodName, value);
 
-        if (value === this.platform.Characteristic.TargetFanState.AUTO) {
+        if (value === this.Characteristic.TargetFanState.AUTO) {
             this.airstageClient.setFanSpeed(
                 this.deviceId,
                 airstage.constants.FAN_SPEED_AUTO,
@@ -297,9 +297,9 @@ class FanAccessory extends Accessory {
                 }
 
                 if (swingState === airstage.constants.TOGGLE_ON) {
-                    value = this.platform.Characteristic.SwingMode.SWING_ENABLED;
+                    value = this.Characteristic.SwingMode.SWING_ENABLED;
                 } else if (swingState === airstage.constants.TOGGLE_OFF) {
-                    value = this.platform.Characteristic.SwingMode.SWING_DISABLED;
+                    value = this.Characteristic.SwingMode.SWING_DISABLED;
                 }
 
                 this._logMethodCallResult(methodName, null, value);
@@ -316,9 +316,9 @@ class FanAccessory extends Accessory {
 
         let swingState = null;
 
-        if (value === this.platform.Characteristic.SwingMode.SWING_ENABLED) {
+        if (value === this.Characteristic.SwingMode.SWING_ENABLED) {
             swingState = airstage.constants.TOGGLE_ON;
-        } else if (value === this.platform.Characteristic.SwingMode.SWING_DISABLED) {
+        } else if (value === this.Characteristic.SwingMode.SWING_DISABLED) {
             swingState = airstage.constants.TOGGLE_OFF;
         }
 

--- a/src/accessories/fan-mode-switch-accessory.js
+++ b/src/accessories/fan-mode-switch-accessory.js
@@ -11,15 +11,15 @@ class FanModeSwitchAccessory extends Accessory {
         this.lastKnownOperationMode = null;
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Switch) ||
-            this.accessory.addService(this.platform.Service.Switch)
+            this.accessory.getService(this.Service.Switch) ||
+            this.accessory.addService(this.Service.Switch)
         );
 
-        this.service.getCharacteristic(this.platform.Characteristic.On)
+        this.service.getCharacteristic(this.Characteristic.On)
             .on('get', this.getOn.bind(this))
             .on('set', this.setOn.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
     }
 

--- a/src/accessories/minimum-heat-mode-switch-accessory.js
+++ b/src/accessories/minimum-heat-mode-switch-accessory.js
@@ -12,15 +12,15 @@ class MinimumHeatModeSwitchAccessory extends Accessory {
         this.lastKnownTargetTemperature = null;
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Switch) ||
-            this.accessory.addService(this.platform.Service.Switch)
+            this.accessory.getService(this.Service.Switch) ||
+            this.accessory.addService(this.Service.Switch)
         );
 
-        this.service.getCharacteristic(this.platform.Characteristic.On)
+        this.service.getCharacteristic(this.Characteristic.On)
             .on('get', this.getOn.bind(this))
             .on('set', this.setOn.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
     }
 

--- a/src/accessories/powerful-switch-accessory.js
+++ b/src/accessories/powerful-switch-accessory.js
@@ -9,15 +9,15 @@ class PowerfulSwitchAccessory extends Accessory {
         super(platform, accessory);
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Switch) ||
-            this.accessory.addService(this.platform.Service.Switch)
+            this.accessory.getService(this.Service.Switch) ||
+            this.accessory.addService(this.Service.Switch)
         );
 
-        this.service.getCharacteristic(this.platform.Characteristic.On)
+        this.service.getCharacteristic(this.Characteristic.On)
             .on('get', this.getOn.bind(this))
             .on('set', this.setOn.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
     }
 

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -9,33 +9,33 @@ class ThermostatAccessory extends Accessory {
         super(platform, accessory);
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Thermostat) ||
-            this.accessory.addService(this.platform.Service.Thermostat)
+            this.accessory.getService(this.Service.Thermostat) ||
+            this.accessory.addService(this.Service.Thermostat)
         );
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.CurrentHeatingCoolingState);
-        this.service.getCharacteristic(this.platform.Characteristic.CurrentHeatingCoolingState)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.CurrentHeatingCoolingState);
+        this.service.getCharacteristic(this.Characteristic.CurrentHeatingCoolingState)
             .on('get', this.getCurrentHeatingCoolingState.bind(this));
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.TargetHeatingCoolingState);
-        this.service.getCharacteristic(this.platform.Characteristic.TargetHeatingCoolingState)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.TargetHeatingCoolingState);
+        this.service.getCharacteristic(this.Characteristic.TargetHeatingCoolingState)
             .on('get', this.getTargetHeatingCoolingState.bind(this))
             .on('set', this.setTargetHeatingCoolingState.bind(this));
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.CurrentTemperature);
-        this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.CurrentTemperature);
+        this.service.getCharacteristic(this.Characteristic.CurrentTemperature)
             .on('get', this.getCurrentTemperature.bind(this));
 
-        this.dynamicServiceCharacteristics.push(this.platform.Characteristic.TargetTemperature);
-        this.service.getCharacteristic(this.platform.Characteristic.TargetTemperature)
+        this.dynamicServiceCharacteristics.push(this.Characteristic.TargetTemperature);
+        this.service.getCharacteristic(this.Characteristic.TargetTemperature)
             .on('get', this.getTargetTemperature.bind(this))
             .on('set', this.setTargetTemperature.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.TemperatureDisplayUnits)
+        this.service.getCharacteristic(this.Characteristic.TemperatureDisplayUnits)
             .on('get', this.getTemperatureDisplayUnits.bind(this))
             .on('set', this.setTemperatureDisplayUnits.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
     }
 
@@ -56,7 +56,7 @@ class ThermostatAccessory extends Accessory {
                 if (powerState === airstage.constants.TOGGLE_OFF) {
                     return callback(
                         null,
-                        this.platform.Characteristic.CurrentHeatingCoolingState.OFF
+                        this.Characteristic.CurrentHeatingCoolingState.OFF
                     );
                 }
 
@@ -83,11 +83,11 @@ class ThermostatAccessory extends Accessory {
                                     }
 
                                     if (temperatureDelta > 0) {
-                                        currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
+                                        currentHeatingCoolingState = this.Characteristic.CurrentHeatingCoolingState.COOL;
                                     } else if (temperatureDelta < 0) {
-                                        currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
+                                        currentHeatingCoolingState = this.Characteristic.CurrentHeatingCoolingState.HEAT;
                                     } else {
-                                        currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.OFF;
+                                        currentHeatingCoolingState = this.Characteristic.CurrentHeatingCoolingState.OFF;
                                     }
 
                                     this._logMethodCallResult(methodName, null, currentHeatingCoolingState);
@@ -98,13 +98,13 @@ class ThermostatAccessory extends Accessory {
                         }
 
                         if (operationMode === airstage.constants.OPERATION_MODE_COOL) {
-                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
+                            currentHeatingCoolingState = this.Characteristic.CurrentHeatingCoolingState.COOL;
                         } else if (operationMode === airstage.constants.OPERATION_MODE_DRY) {
-                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
+                            currentHeatingCoolingState = this.Characteristic.CurrentHeatingCoolingState.COOL;
                         } else if (operationMode === airstage.constants.OPERATION_MODE_FAN) {
-                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.OFF;
+                            currentHeatingCoolingState = this.Characteristic.CurrentHeatingCoolingState.OFF;
                         } else if (operationMode === airstage.constants.OPERATION_MODE_HEAT) {
-                            currentHeatingCoolingState = this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
+                            currentHeatingCoolingState = this.Characteristic.CurrentHeatingCoolingState.HEAT;
                         }
 
                         this._logMethodCallResult(methodName, null, currentHeatingCoolingState);
@@ -133,7 +133,7 @@ class ThermostatAccessory extends Accessory {
                 if (powerState === airstage.constants.TOGGLE_OFF) {
                     return callback(
                         null,
-                        this.platform.Characteristic.TargetHeatingCoolingState.OFF
+                        this.Characteristic.TargetHeatingCoolingState.OFF
                     );
                 }
 
@@ -149,15 +149,15 @@ class ThermostatAccessory extends Accessory {
                         }
 
                         if (operationMode === airstage.constants.OPERATION_MODE_COOL) {
-                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.COOL;
+                            targetHeatingCoolingState = this.Characteristic.TargetHeatingCoolingState.COOL;
                         } else if (operationMode === airstage.constants.OPERATION_MODE_DRY) {
-                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.COOL;
+                            targetHeatingCoolingState = this.Characteristic.TargetHeatingCoolingState.COOL;
                         } else if (operationMode === airstage.constants.OPERATION_MODE_FAN) {
-                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.OFF;
+                            targetHeatingCoolingState = this.Characteristic.TargetHeatingCoolingState.OFF;
                         } else if (operationMode === airstage.constants.OPERATION_MODE_HEAT) {
-                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.HEAT;
+                            targetHeatingCoolingState = this.Characteristic.TargetHeatingCoolingState.HEAT;
                         } else if (operationMode === airstage.constants.OPERATION_MODE_AUTO) {
-                            targetHeatingCoolingState = this.platform.Characteristic.TargetHeatingCoolingState.AUTO;
+                            targetHeatingCoolingState = this.Characteristic.TargetHeatingCoolingState.AUTO;
                         }
 
                         this._logMethodCallResult(methodName, null, targetHeatingCoolingState);
@@ -176,7 +176,7 @@ class ThermostatAccessory extends Accessory {
 
         let operationMode = null;
 
-        if (value === this.platform.Characteristic.TargetHeatingCoolingState.OFF) {
+        if (value === this.Characteristic.TargetHeatingCoolingState.OFF) {
             return this.airstageClient.setPowerState(
                 this.deviceId,
                 airstage.constants.TOGGLE_OFF,
@@ -207,11 +207,11 @@ class ThermostatAccessory extends Accessory {
                     return callback(error);
                 }
 
-                if (value === this.platform.Characteristic.TargetHeatingCoolingState.COOL) {
+                if (value === this.Characteristic.TargetHeatingCoolingState.COOL) {
                     operationMode = airstage.constants.OPERATION_MODE_COOL;
-                } else if (value === this.platform.Characteristic.TargetHeatingCoolingState.HEAT) {
+                } else if (value === this.Characteristic.TargetHeatingCoolingState.HEAT) {
                     operationMode = airstage.constants.OPERATION_MODE_HEAT;
-                } else if (value === this.platform.Characteristic.TargetHeatingCoolingState.AUTO) {
+                } else if (value === this.Characteristic.TargetHeatingCoolingState.AUTO) {
                     operationMode = airstage.constants.OPERATION_MODE_AUTO;
                 }
 
@@ -322,9 +322,9 @@ class ThermostatAccessory extends Accessory {
                 }
 
                 if (temperatureScale === airstage.constants.TEMPERATURE_SCALE_CELSIUS) {
-                    temperatureDisplayUnits = this.platform.Characteristic.TemperatureDisplayUnits.CELSIUS;
+                    temperatureDisplayUnits = this.Characteristic.TemperatureDisplayUnits.CELSIUS;
                 } else if (temperatureScale === airstage.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
-                    temperatureDisplayUnits = this.platform.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
+                    temperatureDisplayUnits = this.Characteristic.TemperatureDisplayUnits.FAHRENHEIT;
                 }
 
                 this._logMethodCallResult(methodName, null, temperatureDisplayUnits);
@@ -341,9 +341,9 @@ class ThermostatAccessory extends Accessory {
 
         let scale = null;
 
-        if (value === this.platform.Characteristic.TemperatureDisplayUnits.FAHRENHEIT) {
+        if (value === this.Characteristic.TemperatureDisplayUnits.FAHRENHEIT) {
             temperatureScale = airstage.constants.TEMPERATURE_SCALE_FAHRENHEIT;
-        } else if (value === this.platform.Characteristic.TemperatureDisplayUnits.CELSIUS) {
+        } else if (value === this.Characteristic.TemperatureDisplayUnits.CELSIUS) {
             temperatureScale = airstage.constants.TEMPERATURE_SCALE_CELSIUS;
         }
 

--- a/src/accessories/vertical-slats-accessory.js
+++ b/src/accessories/vertical-slats-accessory.js
@@ -9,27 +9,27 @@ class VerticalSlatsAccessory extends Accessory {
         super(platform, accessory);
 
         this.service = (
-            this.accessory.getService(this.platform.Service.Slats) ||
-            this.accessory.addService(this.platform.Service.Slats)
+            this.accessory.getService(this.Service.Slats) ||
+            this.accessory.addService(this.Service.Slats)
         );
 
-        this.service.getCharacteristic(this.platform.Characteristic.CurrentSlatState)
+        this.service.getCharacteristic(this.Characteristic.CurrentSlatState)
             .on('get', this.getCurrentSlatState.bind(this))
 
-        this.service.getCharacteristic(this.platform.Characteristic.SlatType)
+        this.service.getCharacteristic(this.Characteristic.SlatType)
             .on('get', this.getSlatType.bind(this))
 
-        this.service.getCharacteristic(this.platform.Characteristic.Name)
+        this.service.getCharacteristic(this.Characteristic.Name)
             .on('get', this.getName.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.SwingMode)
+        this.service.getCharacteristic(this.Characteristic.SwingMode)
             .on('get', this.getSwingMode.bind(this))
             .on('set', this.setSwingMode.bind(this));
 
-        this.service.getCharacteristic(this.platform.Characteristic.CurrentTiltAngle)
+        this.service.getCharacteristic(this.Characteristic.CurrentTiltAngle)
             .on('get', this.getCurrentTiltAngle.bind(this))
 
-        this.service.getCharacteristic(this.platform.Characteristic.TargetTiltAngle)
+        this.service.getCharacteristic(this.Characteristic.TargetTiltAngle)
             .on('get', this.getTargetTiltAngle.bind(this))
             .on('set', this.setTargetTiltAngle.bind(this));
     }
@@ -51,9 +51,9 @@ class VerticalSlatsAccessory extends Accessory {
                 }
 
                 if (swingState === airstage.constants.TOGGLE_ON) {
-                    value = this.platform.Characteristic.CurrentSlatState.SWINGING;
+                    value = this.Characteristic.CurrentSlatState.SWINGING;
                 } else if (swingState === airstage.constants.TOGGLE_OFF) {
-                    value = this.platform.Characteristic.CurrentSlatState.FIXED;
+                    value = this.Characteristic.CurrentSlatState.FIXED;
                 }
 
                 callback(null, value);
@@ -66,7 +66,7 @@ class VerticalSlatsAccessory extends Accessory {
 
         this._logMethodCall(methodName);
 
-        const value = this.platform.Characteristic.SlatType.VERTICAL;
+        const value = this.Characteristic.SlatType.VERTICAL;
 
         this._logMethodCallResult(methodName, null, value);
 
@@ -113,9 +113,9 @@ class VerticalSlatsAccessory extends Accessory {
                 }
 
                 if (swingState === airstage.constants.TOGGLE_ON) {
-                    value = this.platform.Characteristic.SwingMode.SWING_ENABLED;
+                    value = this.Characteristic.SwingMode.SWING_ENABLED;
                 } else if (swingState === airstage.constants.TOGGLE_OFF) {
-                    value = this.platform.Characteristic.SwingMode.SWING_DISABLED;
+                    value = this.Characteristic.SwingMode.SWING_DISABLED;
                 }
 
                 this._logMethodCallResult(methodName, null, value);
@@ -132,9 +132,9 @@ class VerticalSlatsAccessory extends Accessory {
 
         let swingState = null;
 
-        if (value === this.platform.Characteristic.SwingMode.SWING_ENABLED) {
+        if (value === this.Characteristic.SwingMode.SWING_ENABLED) {
             swingState = airstage.constants.TOGGLE_ON;
-        } else if (value === this.platform.Characteristic.SwingMode.SWING_DISABLED) {
+        } else if (value === this.Characteristic.SwingMode.SWING_DISABLED) {
             swingState = airstage.constants.TOGGLE_OFF;
         }
 

--- a/src/airstage/apiv1/client.js
+++ b/src/airstage/apiv1/client.js
@@ -232,7 +232,7 @@ class Client {
         }
 
         requestOptions = {
-            'hostname': this._getHostname(),
+            'hostname': null,
             'path': path,
             'method': constants.REQUEST_METHOD_GET,
             'headers': requestHeaders
@@ -260,7 +260,7 @@ class Client {
         }
 
         requestOptions = {
-            'hostname': this._getHostname(),
+            'hostname': null,
             'path': path,
             'method': method,
             'headers': requestHeaders
@@ -270,7 +270,16 @@ class Client {
     }
 
     _makeHttpsRequest(requestOptions, requestBodyJson, callback) {
+        const hostname = this._getHostname();
         let result = structuredClone(constants.REQUEST_RESULT);
+
+        if (hostname === null) {
+            result.error = 'Could not determine hostname for region: ' + this.region;
+
+            return callback(result);
+        }
+
+        requestOptions.hostname = hostname;
 
         const request = https.request(requestOptions, (response) => {
             result.statusCode = response.statusCode;

--- a/src/airstage/client.js
+++ b/src/airstage/client.js
@@ -261,9 +261,10 @@ class Client {
                 }
 
                 if (operationMode === constants.OPERATION_MODE_DRY) {
-                    // The fan speed is automatically set to "AUTO" on the
-                    // Airstage side, so let's reflect that in the local
-                    // device cache
+                    // These things automatically happen on the Airstage side
+                    // when turning on dry mode, so let's update
+                    // them in the local device cache:
+                    // - The fan speed is set to "AUTO"
                     this._setDeviceParameterCache(
                         deviceId,
                         {
@@ -687,11 +688,13 @@ class Client {
                 }
 
                 if (toggle === constants.TOGGLE_ON) {
-                    // The power state is automatically set to "ON", the fan
-                    // speed is automatically set to "AUTO", the operation
-                    // mode is automatically set to "HEAT", and the temperature
-                    // is automatically set to 50 degrees (F) on the Airstage
-                    // side, so let's reflect that in the local device cache
+                    // These things automatically happen on the Airstage side
+                    // when turning on minimum heat, so let's update
+                    // them in the local device cache:
+                    // - The power state is set to "ON"
+                    // - The fan speed is set to "AUTO"
+                    // - The operation mode is set to "HEAT"
+                    // - The temperature is set to 10 degrees (C)
                     this._setDeviceParameterCache(
                         deviceId,
                         {
@@ -716,8 +719,10 @@ class Client {
                         }
                     );
                 } else if (toggle === constants.TOGGLE_OFF) {
-                    // The power state is automatically set to "OFF" on the
-                    // Airstage side, so let's reflect that in the local device cache
+                    // These things automatically happen on the Airstage side
+                    // when turning off minimum heat, so let's update
+                    // them in the local device cache:
+                    // - The power state is set to "OFF"
                     this._setDeviceParameterCache(
                         deviceId,
                         {

--- a/src/airstage/client.js
+++ b/src/airstage/client.js
@@ -31,7 +31,7 @@ class Client {
             refreshToken || null
         );
 
-        this.resetUserCache();
+        this.resetUserMetadataCache();
         this.resetDeviceCache();
     }
 
@@ -936,7 +936,7 @@ class Client {
         }).bind(this));
     }
 
-    resetUserCache() {
+    resetUserMetadataCache() {
         this._userMetadataCache = {};
     }
 

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -8,6 +8,9 @@ class PlatformAccessoryManager {
 
     constructor(platform) {
         this.platform = platform;
+
+        this.Service = this.platform.Service;
+        this.Characteristic = this.platform.Characteristic;
     }
 
     registerThermostatAccessory(deviceId, deviceName, model) {
@@ -285,11 +288,11 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.CurrentHeatingCoolingState,
-                this.platform.Characteristic.TargetHeatingCoolingState,
-                this.platform.Characteristic.CurrentTemperature,
-                this.platform.Characteristic.TargetTemperature,
-                this.platform.Characteristic.TemperatureDisplayUnits
+                this.Characteristic.CurrentHeatingCoolingState,
+                this.Characteristic.TargetHeatingCoolingState,
+                this.Characteristic.CurrentTemperature,
+                this.Characteristic.TargetTemperature,
+                this.Characteristic.TemperatureDisplayUnits
             ]
         );
     }
@@ -305,11 +308,11 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.Active,
-                this.platform.Characteristic.CurrentFanState,
-                this.platform.Characteristic.TargetFanState,
-                this.platform.Characteristic.RotationSpeed,
-                this.platform.Characteristic.SwingMode
+                this.Characteristic.Active,
+                this.Characteristic.CurrentFanState,
+                this.Characteristic.TargetFanState,
+                this.Characteristic.RotationSpeed,
+                this.Characteristic.SwingMode
             ]
         );
     }
@@ -325,10 +328,10 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.CurrentSlatState,
-                this.platform.Characteristic.SwingMode,
-                this.platform.Characteristic.CurrentTiltAngle,
-                this.platform.Characteristic.TargetTiltAngle
+                this.Characteristic.CurrentSlatState,
+                this.Characteristic.SwingMode,
+                this.Characteristic.CurrentTiltAngle,
+                this.Characteristic.TargetTiltAngle
             ]
         );
     }
@@ -344,7 +347,7 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.On
+                this.Characteristic.On
             ]
         );
     }
@@ -360,7 +363,7 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.On
+                this.Characteristic.On
             ]
         );
     }
@@ -376,7 +379,7 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.On
+                this.Characteristic.On
             ]
         );
     }
@@ -392,7 +395,7 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.On
+                this.Characteristic.On
             ]
         );
     }
@@ -408,7 +411,7 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.On
+                this.Characteristic.On
             ]
         );
     }
@@ -424,7 +427,7 @@ class PlatformAccessoryManager {
         return this._refreshAccessoryCharacteristics(
             accessory,
             [
-                this.platform.Characteristic.On
+                this.Characteristic.On
             ]
         );
     }
@@ -524,7 +527,7 @@ class PlatformAccessoryManager {
 
     _refreshAccessoryCharacteristics(accessory, characteristicClasses) {
         const service = accessory.services.find(
-            service => (service instanceof this.platform.Service.AccessoryInformation) === false
+            service => (service instanceof this.Service.AccessoryInformation) === false
         ) || null;
 
         if (service === null) {

--- a/src/platform.js
+++ b/src/platform.js
@@ -61,39 +61,11 @@ class Platform {
     discoverDevices() {
         this.airstageClient.refreshTokenOrAuthenticate((function(error) {
             if (error) {
-                return this.log.error('Error when attempting to authenticate with Airbridge:', error);
+                return this.log.error('Error when attempting to authenticate with Airstage:', error);
             }
 
             this._updateConfigWithAccessToken();
-
-            this.airstageClient.getUserMetadata((function(error) {
-                if (error) {
-                    return this.log.error('Error when attempting to communicate with Airbridge:', error);
-                }
-
-                this.airstageClient.getDevices(null, (function(error, devices) {
-                    if (error) {
-                        return this.log.error('Error when attempting to communicate with Airbridge:', error);
-                    }
-
-                    const deviceIds = Object.keys(devices.metadata);
-
-                    deviceIds.forEach(function(deviceId) {
-                        const deviceMetadata = devices.metadata[deviceId];
-                        const deviceParameters = devices.parameters[deviceId];
-                        const deviceName = deviceMetadata.deviceName;
-                        const model = deviceParameters[airstage.apiv1.constants.PARAMETER_MODEL];
-
-                        this._configureAirstageDevice(
-                            deviceId,
-                            deviceMetadata,
-                            deviceParameters,
-                            deviceName,
-                            model
-                        );
-                    }, this);
-                }).bind(this));
-            }).bind(this));
+            this._configureAirstageDevices();
         }).bind(this));
     }
 
@@ -113,13 +85,43 @@ class Platform {
         }
     }
 
+    _configureAirstageDevices() {
+        this.airstageClient.getUserMetadata((function(error) {
+            if (error) {
+                return this.log.error('Error when attempting to communicate with Airstage:', error);
+            }
+
+            this.airstageClient.getDevices(null, (function(error, devices) {
+                if (error) {
+                    return this.log.error('Error when attempting to communicate with Airstage:', error);
+                }
+
+                const deviceIds = Object.keys(devices.metadata);
+
+                deviceIds.forEach(function(deviceId) {
+                    const deviceMetadata = devices.metadata[deviceId];
+                    const deviceParameters = devices.parameters[deviceId];
+                    const deviceName = deviceMetadata.deviceName;
+                    const model = deviceParameters[airstage.apiv1.constants.PARAMETER_MODEL];
+
+                    this._configureAirstageDevice(
+                        deviceId,
+                        deviceParameters,
+                        deviceName,
+                        model
+                    );
+                }, this);
+            }).bind(this));
+        }).bind(this));
+    }
+
     _configureAirstageDevice(
         deviceId,
-        deviceMetadata,
         deviceParameters,
         deviceName,
         model
     ) {
+        // Thermostat
         if (this.config.enableThermostat) {
             this.accessoryManager.registerThermostatAccessory(
                 deviceId,
@@ -133,6 +135,7 @@ class Platform {
             );
         }
 
+        // Fan
         if (this.config.enableFan) {
             this.accessoryManager.registerFanAccessory(
                 deviceId,
@@ -146,6 +149,7 @@ class Platform {
             );
         }
 
+        // Vertical slats
         if (this.config.enableVerticalSlats) {
             this.accessoryManager.registerVerticalSlatsAccessory(
                 deviceId,
@@ -159,6 +163,7 @@ class Platform {
             );
         }
 
+        // "Dry Mode" switch
         if (this.config.enableDryModeSwitch) {
             this.accessoryManager.registerDryModeSwitchAccessory(
                 deviceId,
@@ -172,6 +177,7 @@ class Platform {
             );
         }
 
+        // "Economy" switch
         if (this.config.enableEconomySwitch) {
             this.accessoryManager.registerEconomySwitchAccessory(
                 deviceId,
@@ -185,6 +191,7 @@ class Platform {
             );
         }
 
+        // "Energy Saving Fan" switch
         if (this.config.enableEnergySavingFanSwitch) {
             this.accessoryManager.registerEnergySavingFanSwitchAccessory(
                 deviceId,
@@ -198,6 +205,7 @@ class Platform {
             );
         }
 
+        // "Fan Mode" switch
         if (this.config.enableFanModeSwitch) {
             this.accessoryManager.registerFanModeSwitchAccessory(
                 deviceId,
@@ -211,6 +219,7 @@ class Platform {
             );
         }
 
+        // "Minimum Heat Mode" switch
         if (this.config.enableMinimumHeatModeSwitch) {
             this.accessoryManager.registerMinimumHeatModeSwitchAccessory(
                 deviceId,
@@ -224,6 +233,7 @@ class Platform {
             );
         }
 
+        // "Powerful" switch
         if (this.config.enablePowerfulSwitch) {
             this.accessoryManager.registerPowerfulSwitchAccessory(
                 deviceId,
@@ -241,7 +251,7 @@ class Platform {
     _refreshAirstageClientToken() {
         this.airstageClient.refreshToken((function(error) {
             if (error) {
-                return this.log.error('Error when attempting to refresh Airbridge access token:', error);
+                return this.log.error('Error when attempting to refresh Airstage access token:', error);
             }
 
             this._updateConfigWithAccessToken();
@@ -257,7 +267,7 @@ class Platform {
         this.airstageClient.getUserMetadata(
             (function(error) {
                 if (error) {
-                    return this.log.error('Error when attempting to communicate with Airbridge:', error);
+                    return this.log.error('Error when attempting to communicate with Airstage:', error);
                 }
 
                 this.log.debug('Refreshed Airstage client user metadata cache');
@@ -267,7 +277,7 @@ class Platform {
                     limit,
                     (function(error, devices) {
                         if (error) {
-                            return this.log.error('Error when attempting to communicate with Airbridge:', error);
+                            return this.log.error('Error when attempting to communicate with Airstage:', error);
                         }
 
                         this.log.debug('Refreshed Airstage client device cache');

--- a/src/platform.js
+++ b/src/platform.js
@@ -253,7 +253,7 @@ class Platform {
     _refreshAirstageClientCache() {
         const limit = 100;
 
-        this.airstageClient.resetUserCache();
+        this.airstageClient.resetUserMetadataCache();
         this.airstageClient.getUserMetadata(
             (function(error) {
                 if (error) {

--- a/test/airstage/apiv1/test-client.js
+++ b/test/airstage/apiv1/test-client.js
@@ -14,9 +14,13 @@ const clientWithAccessToken = new airstage.apiv1.Client(
     '2099-01-01',
     'existingRefreshToken'
 );
+const clientWithoutAccessToken = new airstage.apiv1.Client(
+    'us',
+    'United States',
+    'en'
+);
 
 test('airstage.apiv1.Client#postUsersSignIn calls _makeHttpsRequest with success', (context, done) => {
-    const clientWithoutAccessToken = new airstage.apiv1.Client('us', 'United States', 'en');
     const expectedResponse = {
         'accessToken': 'testAccessToken',
         'expiresIn': 3600,
@@ -50,12 +54,15 @@ test('airstage.apiv1.Client#postUsersSignIn calls _makeHttpsRequest with success
         assert.strictEqual(result.error, null);
         assert.strictEqual(result.response, expectedResponse);
 
+        clientWithoutAccessToken.accessToken = null;
+        clientWithoutAccessToken.accessTokenExpiry = null;
+        clientWithoutAccessToken.refreshToken = null;
+
         done();
     });
 });
 
 test('airstage.apiv1.Client#postUsersSignIn calls _makeHttpsRequest with error', (context, done) => {
-    const clientWithoutAccessToken = new airstage.apiv1.Client('us', 'United States', 'en');
     const expectedError = 'Error';
     context.mock.method(
         clientWithoutAccessToken,
@@ -742,6 +749,35 @@ test('airstage.apiv1.Client#getGroups calls _makeHttpsRequest with error', (cont
 
     clientWithAccessToken.getGroups((result) => {
         assert.strictEqual(result.error, expectedError);
+        assert.strictEqual(result.response, '');
+
+        done();
+    });
+});
+
+test('airstage.apiv1.Client#getGroups with "Could not determine hostname" error', (context, done) => {
+    const clientWithInvalidRegion = new airstage.apiv1.Client(
+        'cn',
+        'China',
+        'en',
+        null,
+        null,
+        'existingAccessToken',
+        '2099-01-01',
+        'existingRefreshToken'
+    );
+
+    clientWithInvalidRegion.getGroups((result) => {
+        assert.strictEqual(result.error, 'Could not determine hostname for region: cn');
+        assert.strictEqual(result.response, '');
+
+        done();
+    });
+});
+
+test('airstage.apiv1.Client#getGroups with "Access token not set" error', (context, done) => {
+    clientWithoutAccessToken.getGroups((result) => {
+        assert.strictEqual(result.error, 'Access token not set');
         assert.strictEqual(result.response, '');
 
         done();

--- a/test/airstage/test-client.js
+++ b/test/airstage/test-client.js
@@ -2178,3 +2178,34 @@ test('airstage.Client#getParameter calls _apiClient.getDevice with "Parameter no
         done();
     });
 });
+
+test('airstage.Client#getParameter with "Could not determine hostname" error', (context, done) => {
+    const clientWithInvalidRegion = new airstage.Client(
+        'cn',
+        'China',
+        'en',
+        null,
+        null,
+        null,
+        null,
+        'existingAccessToken',
+        '2099-01-01',
+        'existingRefreshToken'
+    );
+
+    clientWithInvalidRegion.getParameter('12345', 'iu_indoor_tmp', (error, result) => {
+        assert.strictEqual(error, 'Could not determine hostname for region: cn');
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.Client#getParameter with "Access token not set" error', (context, done) => {
+    clientWithoutAccessToken.getParameter('12345', 'iu_indoor_tmp', (error, result) => {
+        assert.strictEqual(error, 'Access token not set');
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});

--- a/test/airstage/test-client.js
+++ b/test/airstage/test-client.js
@@ -283,7 +283,7 @@ test('airstage.Client#getTemperatureScale calls _apiClient.getUsersMe with succe
         assert.strictEqual(mockedMethod.calls.length, 1);
         assert.strictEqual(mockedMethod.calls[0].arguments.length, 1);
     });
-    clientWithAccessToken.resetUserCache();
+    clientWithAccessToken.resetUserMetadataCache();
 
     clientWithAccessToken.getTemperatureScale((error, result) => {
         assert.strictEqual(error, null);
@@ -308,7 +308,7 @@ test('airstage.Client#getTemperatureScale calls _apiClient.getUsersMe with error
         assert.strictEqual(mockedMethod.calls.length, 1);
         assert.strictEqual(mockedMethod.calls[0].arguments.length, 1);
     });
-    clientWithAccessToken.resetUserCache();
+    clientWithAccessToken.resetUserMetadataCache();
 
     clientWithAccessToken.getTemperatureScale((error, result) => {
         assert.strictEqual(error, expectedError);
@@ -337,7 +337,7 @@ test('airstage.Client#setTemperatureScale calls _apiClient.putUsersMe with succe
         assert.strictEqual(mockedMethod.calls[0].arguments[0], 'tempUnit');
         assert.strictEqual(mockedMethod.calls[0].arguments[1], 'F');
     });
-    clientWithAccessToken.resetUserCache();
+    clientWithAccessToken.resetUserMetadataCache();
 
     clientWithAccessToken.setTemperatureScale('F', (error, result) => {
         assert.strictEqual(error, null);
@@ -367,7 +367,7 @@ test('airstage.Client#setTemperatureScale calls _apiClient.putUsersMe with error
         assert.strictEqual(mockedMethod.calls[0].arguments[0], 'tempUnit');
         assert.strictEqual(mockedMethod.calls[0].arguments[1], 'F');
     });
-    clientWithAccessToken.resetUserCache();
+    clientWithAccessToken.resetUserMetadataCache();
 
     clientWithAccessToken.setTemperatureScale('F', (error, result) => {
         assert.strictEqual(error, expectedError);

--- a/test/test-platform-accessory-manager.js
+++ b/test/test-platform-accessory-manager.js
@@ -250,50 +250,6 @@ test('PlatformAccessoryManager#registerVerticalSlatsAccessory registers existing
     resetMocks();
 });
 
-test('PlatformAccessoryManager#registerVerticalSlatsAccessory registers new accessory', (context) => {
-    platformAccessoryManager.registerVerticalSlatsAccessory(deviceId, deviceName, deviceModel);
-
-    const mockedMethod = mockPlatform.api.registerPlatformAccessories.mock;
-    assert.strictEqual(mockedMethod.calls.length, 1);
-    assert.strictEqual(mockedMethod.calls[0].arguments[0], settings.PLUGIN_NAME);
-    assert.strictEqual(mockedMethod.calls[0].arguments[1], settings.PLATFORM_NAME);
-    const mockPlatformAccessory = mockedMethod.calls[0].arguments[2][0];
-    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Vertical Slats');
-    assert.strictEqual(mockPlatformAccessory.context.airstageClient, airstageClient);
-    assert.strictEqual(mockPlatformAccessory.context.deviceId, deviceId);
-    assert.strictEqual(mockPlatformAccessory.context.model, deviceModel);
-    assert.strictEqual(mockPlatform.accessories.length, 1);
-    assert.strictEqual(mockPlatform.accessories[0], mockPlatformAccessory);
-
-    resetMocks();
-});
-
-test('PlatformAccessoryManager#registerDryModeSwitchAccessory registers existing accessory', (context) => {
-    const existingUuid = hap.uuid.generate(
-        deviceId + '-dry-mode-switch'
-    );
-    const existingPlatformAccessory = new MockPlatformAccessory(
-        'Test Device Dry Mode Switch',
-        existingUuid
-    );
-    mockPlatform.accessories = [existingPlatformAccessory];
-
-    platformAccessoryManager.registerDryModeSwitchAccessory(deviceId, deviceName, deviceModel);
-
-    const mockedMethod = mockPlatform.api.updatePlatformAccessories.mock;
-    assert.strictEqual(mockedMethod.calls.length, 1);
-    const mockPlatformAccessory = mockedMethod.calls[0].arguments[0][0];
-    assert.strictEqual(mockPlatformAccessory, existingPlatformAccessory);
-    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Dry Mode Switch');
-    assert.strictEqual(mockPlatformAccessory.context.airstageClient, airstageClient);
-    assert.strictEqual(mockPlatformAccessory.context.deviceId, deviceId);
-    assert.strictEqual(mockPlatformAccessory.context.model, deviceModel);
-    assert.strictEqual(mockPlatform.accessories.length, 1);
-    assert.strictEqual(mockPlatform.accessories[0], mockPlatformAccessory);
-
-    resetMocks();
-});
-
 test('PlatformAccessoryManager#registerDryModeSwitchAccessory registers new accessory', (context) => {
     platformAccessoryManager.registerDryModeSwitchAccessory(deviceId, deviceName, deviceModel);
 


### PR DESCRIPTION
If you pass in an unsupported region (anything besides `'us'`, `'eu'`) - you'll get an error message when you attempt to make Airstage API requests, like this:

```
Could not determine hostname for region: cn
```