### PR TITLE
Replace `VerticalSlatsAccessory` with `VerticalAirflowDirectionAccessory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ A Homebridge plugin to control devices that use the Fujitsu Airstage API.
     "refreshToken": null,
     "enableThermostat": true,
     "enableFan": true,
-    "enableVerticalSlats": false,
     "enableVerticalAirflowDirection": false,
     "enableDryModeSwitch": false,
     "enableEconomySwitch": false,

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A Homebridge plugin to control devices that use the Fujitsu Airstage API.
     "enableThermostat": true,
     "enableFan": true,
     "enableVerticalSlats": false,
+    "enableVerticalAirflowDirection": false,
     "enableDryModeSwitch": false,
     "enableEconomySwitch": false,
     "enableEnergySavingFanSwitch": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -80,11 +80,6 @@
                 "type": "boolean",
                 "default": true
             },
-            "enableVerticalSlats": {
-                "title": "Enable vertical slats control",
-                "type": "boolean",
-                "default": false
-            },
             "enableVerticalAirflowDirection": {
                 "title": "Enable vertical airflow direction control",
                 "type": "boolean",

--- a/config.schema.json
+++ b/config.schema.json
@@ -85,6 +85,11 @@
                 "type": "boolean",
                 "default": false
             },
+            "enableVerticalAirflowDirection": {
+                "title": "Enable vertical airflow direction control",
+                "type": "boolean",
+                "default": false
+            },
             "enableDryModeSwitch": {
                 "title": "Enable 'Dry Mode' switch",
                 "type": "boolean",

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -334,6 +334,8 @@ class FanAccessory extends Accessory {
 
                 this._logMethodCallResult(methodName, null, null);
 
+                this._refreshRelatedAccessoryCharacteristics();
+
                 callback(null);
             }).bind(this)
         );
@@ -363,6 +365,7 @@ class FanAccessory extends Accessory {
         const accessoryManager = this.platform.accessoryManager;
 
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
     }
 }
 

--- a/src/accessories/index.js
+++ b/src/accessories/index.js
@@ -3,6 +3,7 @@
 const ThermostatAccessory = require('./thermostat-accessory');
 const FanAccessory = require('./fan-accessory');
 const VerticalSlatsAccessory = require('./vertical-slats-accessory');
+const VerticalAirflowDirectionAccessory = require('./vertical-airflow-direction-accessory');
 const DryModeSwitchAccessory = require('./dry-mode-switch-accessory');
 const EconomySwitchAccessory = require('./economy-switch-accessory');
 const EnergySavingFanSwitchAccessory = require('./energy-saving-fan-switch-accessory');
@@ -14,6 +15,7 @@ module.exports = {
     ThermostatAccessory,
     FanAccessory,
     VerticalSlatsAccessory,
+    VerticalAirflowDirectionAccessory,
     DryModeSwitchAccessory,
     EconomySwitchAccessory,
     EnergySavingFanSwitchAccessory,

--- a/src/accessories/vertical-airflow-direction-accessory.js
+++ b/src/accessories/vertical-airflow-direction-accessory.js
@@ -1,0 +1,285 @@
+'use strict';
+
+const Accessory = require('./accessory');
+const airstage = require('./../airstage');
+
+class VerticalAirflowDirectionAccessory extends Accessory {
+
+    constructor(platform, accessory) {
+        super(platform, accessory);
+
+        // Ideally we'd use the Slats service for this, but it's not supported
+        // by Apple Home currently. Let's use the Fanv2 service instead
+        this.service = (
+            this.accessory.getService(this.Service.Fanv2) ||
+            this.accessory.addService(this.Service.Fanv2)
+        );
+
+        this.dynamicServiceCharacteristics.push(this.Characteristic.Active);
+        this.service.getCharacteristic(this.Characteristic.Active)
+            .on('get', this.getActive.bind(this))
+            .on('set', this.setActive.bind(this))
+
+        this.dynamicServiceCharacteristics.push(this.Characteristic.CurrentFanState);
+        this.service.getCharacteristic(this.Characteristic.CurrentFanState)
+            .on('get', this.getCurrentFanState.bind(this));
+
+        this.service.getCharacteristic(this.Characteristic.Name)
+            .on('get', this.getName.bind(this));
+
+        this.dynamicServiceCharacteristics.push(this.Characteristic.RotationSpeed);
+        this.service.getCharacteristic(this.Characteristic.RotationSpeed)
+            .on('get', this.getRotationSpeed.bind(this))
+            .on('set', this.setRotationSpeed.bind(this));
+
+        this._setAirflowVerticalDirectionHandle = null;
+    }
+
+    getActive(callback) {
+        const methodName = this.getActive.name;
+
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getAirflowVerticalSwingState(
+            this.deviceId,
+            (function(error, swingState) {
+                let value = null;
+
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (swingState === airstage.constants.TOGGLE_ON) {
+                    value = this.Characteristic.Active.INACTIVE;
+                } else if (swingState === airstage.constants.TOGGLE_OFF) {
+                    value = this.Characteristic.Active.ACTIVE;
+                }
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
+    }
+
+    setActive(value, callback) {
+        const methodName = this.setActive.name;
+
+        this._logMethodCall(methodName, value);
+
+        let swingState = null;
+
+        if (value === this.Characteristic.Active.ACTIVE) {
+            swingState = airstage.constants.TOGGLE_OFF;
+        } else if (value === this.Characteristic.Active.INACTIVE) {
+            swingState = airstage.constants.TOGGLE_ON;
+        }
+
+        this.airstageClient.setAirflowVerticalSwingState(
+            this.deviceId,
+            swingState,
+            (function(error) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error);
+                }
+
+                this._logMethodCallResult(methodName, null, null);
+
+                this._refreshDynamicServiceCharacteristics();
+                this._refreshRelatedAccessoryCharacteristics();
+
+                callback(null);
+            }).bind(this)
+        );
+    }
+
+    getCurrentFanState(callback) {
+        const methodName = this.getCurrentFanState.name;
+
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
+                let value = null;
+
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (powerState === airstage.constants.TOGGLE_OFF) {
+                    value = this.Characteristic.CurrentFanState.INACTIVE;
+
+                    this._logMethodCallResult(methodName, null, value);
+
+                    return callback(null, value);
+                }
+
+                this.airstageClient.getAirflowVerticalSwingState(
+                    this.deviceId,
+                    (function(error, swingState) {
+                        if (error) {
+                            this._logMethodCallResult(methodName, error);
+
+                            return callback(error, null);
+                        }
+
+                        if (swingState === airstage.constants.TOGGLE_ON) {
+                            value = this.Characteristic.CurrentFanState.IDLE;
+                        } else if (swingState === airstage.constants.TOGGLE_OFF) {
+                            value = this.Characteristic.CurrentFanState.BLOWING_AIR;
+                        }
+
+                        this._logMethodCallResult(methodName, null, value);
+
+                        callback(null, value);
+                    }).bind(this)
+                );
+            }).bind(this)
+        );
+    }
+
+    getName(callback) {
+        const methodName = this.getName.name;
+
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getName(
+            this.deviceId,
+            (function(error, name) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                const value = name + ' Vertical Airflow Direction';
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
+    }
+
+    getRotationSpeed(callback) {
+        const methodName = this.getRotationSpeed.name;
+
+        this._logMethodCall(methodName);
+
+        let value = null;
+
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (powerState === airstage.constants.TOGGLE_OFF) {
+                    value = 0;
+
+                    this._logMethodCallResult(methodName, null, value);
+
+                    return callback(null, value);
+                }
+
+                this.airstageClient.getAirflowVerticalDirection(
+                    this.deviceId,
+                    (function(error, airflowVerticalDirection) {
+                        if (error) {
+                            this._logMethodCallResult(methodName, error);
+
+                            return callback(error, null);
+                        }
+
+                        if (airflowVerticalDirection === 1) {
+                            value = 25;
+                        } else if (airflowVerticalDirection === 2) {
+                            value = 50;
+                        } else if (airflowVerticalDirection === 3) {
+                            value = 75
+                        } else if (airflowVerticalDirection === 4) {
+                            value = 100;
+                        }
+
+                        this._logMethodCallResult(methodName, null, value);
+
+                        callback(null, value);
+                    }).bind(this)
+                );
+            }).bind(this)
+        );
+    }
+
+    setRotationSpeed(value, callback) {
+        const methodName = this.setRotationSpeed.name;
+
+        this._logMethodCall(methodName, value);
+
+        let airflowVerticalDirection = null;
+
+        if (value <= 25) {
+            airflowVerticalDirection = 1;
+        } else if (value <= 50) {
+            airflowVerticalDirection = 2;
+        } else if (value <= 75) {
+            airflowVerticalDirection = 3;
+        } else if (value <= 100) {
+            airflowVerticalDirection = 4;
+        }
+
+        if (this._setAirflowVerticalDirectionHandle !== null) {
+            clearTimeout(this._setAirflowVerticalDirectionHandle);
+            this._setAirflowVerticalDirectionHandle = null;
+        }
+
+        this._setAirflowVerticalDirectionHandle = setTimeout(
+            (function() {
+                this._setAirflowVerticalDirection(
+                    methodName,
+                    airflowVerticalDirection
+                );
+            }).bind(this),
+            500
+        );
+
+        callback(null);
+    }
+
+    _setAirflowVerticalDirection(methodName, airflowVerticalDirection) {
+        this.airstageClient.setAirflowVerticalDirection(
+            this.deviceId,
+            airflowVerticalDirection,
+            (function(error) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return;
+                }
+
+                this._logMethodCallResult(methodName, null, null);
+
+                this._refreshDynamicServiceCharacteristics();
+
+                this._setAirflowVerticalDirectionHandle = null;
+            }).bind(this)
+        );
+    }
+
+    _refreshRelatedAccessoryCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
+
+        accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
+    }
+}
+
+module.exports = VerticalAirflowDirectionAccessory;

--- a/src/accessories/vertical-slats-accessory.js
+++ b/src/accessories/vertical-slats-accessory.js
@@ -3,6 +3,11 @@
 const Accessory = require('./accessory');
 const airstage = require('./../airstage');
 
+/**
+ * The Slats service isn't supported by Apple Home currently, so this Accessory
+ * class isn't used. The VerticalAirflowDirectionAccessory is used to control
+ * the vertical tilt angle, using the Lightbulb service.
+ */
 class VerticalSlatsAccessory extends Accessory {
 
     constructor(platform, accessory) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@
 module.exports.ACCESSORY_SUFFIX_THERMOSTAT = 'thermostat';
 module.exports.ACCESSORY_SUFFIX_FAN = 'fan';
 module.exports.ACCESSORY_SUFFIX_VERTICAL_SLATS = 'vertical-slats';
+module.exports.ACCESSORY_SUFFIX_VERTICAL_AIRFLOW_DIRECTION = 'vertical-airflow-direction';
 module.exports.ACCESSORY_SUFFIX_DRY_MODE_SWITCH = 'dry-mode-switch';
 module.exports.ACCESSORY_SUFFIX_ECONOMY_SWITCH = 'economy-switch';
 module.exports.ACCESSORY_SUFFIX_ENERGY_SAVING_FAN_SWITCH = 'energy-saving-fan-switch';

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -79,6 +79,28 @@ class PlatformAccessoryManager {
         }
     }
 
+    registerVerticalAirflowDirectionAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_VERTICAL_AIRFLOW_DIRECTION;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.VerticalAirflowDirectionAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.VerticalAirflowDirectionAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
     registerDryModeSwitchAccessory(deviceId, deviceName, model) {
         const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
         const existingAccessory = this._getExistingAccessory(deviceId, suffix);
@@ -229,6 +251,12 @@ class PlatformAccessoryManager {
         this._unregisterAccessory(deviceId, deviceName, suffix);
     }
 
+    unregisterVerticalAirflowDirectionAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_VERTICAL_AIRFLOW_DIRECTION;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
     unregisterDryModeSwitchAccessory(deviceId, deviceName) {
         const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
 
@@ -269,6 +297,7 @@ class PlatformAccessoryManager {
         this.refreshThermostatAccessoryCharacteristics(deviceId);
         this.refreshFanAccessoryCharacteristics(deviceId);
         this.refreshVerticalSlatsAccessoryCharacteristics(deviceId);
+        this.refreshVerticalAirflowDirectionAccessoryCharacteristics(deviceId);
         this.refreshDryModeSwitchAccessoryCharacteristics(deviceId);
         this.refreshEconomySwitchAccessoryCharacteristics(deviceId);
         this.refreshEnergySavingFanSwitchAccessoryCharacteristics(deviceId);
@@ -332,6 +361,24 @@ class PlatformAccessoryManager {
                 this.Characteristic.SwingMode,
                 this.Characteristic.CurrentTiltAngle,
                 this.Characteristic.TargetTiltAngle
+            ]
+        );
+    }
+
+    refreshVerticalAirflowDirectionAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_VERTICAL_AIRFLOW_DIRECTION;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.Characteristic.Active,
+                this.Characteristic.CurrentFanState,
+                this.Characteristic.RotationSpeed
             ]
         );
     }

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -248,7 +248,7 @@ class PlatformAccessoryManager {
     unregisterVerticalSlatsAccessory(deviceId, deviceName) {
         const suffix = constants.ACCESSORY_SUFFIX_VERTICAL_SLATS;
 
-        this._unregisterAccessory(deviceId, deviceName, suffix);
+        this._unregisterAccessory(deviceId, deviceName, suffix, false);
     }
 
     unregisterVerticalAirflowDirectionAccessory(deviceId, deviceName) {
@@ -509,22 +509,26 @@ class PlatformAccessoryManager {
         this.platform.api.updatePlatformAccessories([existingAccessory]);
     }
 
-    _unregisterAccessory(deviceId, deviceName, suffix) {
+    _unregisterAccessory(deviceId, deviceName, suffix, log = true) {
         const accessoryName = this._getAccessoryName(deviceName, suffix);
         const existingAccessory = this._getExistingAccessory(deviceId, suffix);
 
-        this.platform.log.info(
-            'Not adding accessory because it is disabled in the config:',
-            accessoryName
-        );
+        if (log === true) {
+            this.platform.log.info(
+                'Not adding accessory because it is disabled in the config:',
+                accessoryName
+            );
+        }
 
         if (existingAccessory) {
-            this._unregisterExistingAccessory(existingAccessory);
+            this._unregisterExistingAccessory(existingAccessory, log);
         }
     }
 
-    _unregisterExistingAccessory(existingAccessory) {
-        this.platform.log.info('Removing existing accessory from cache:', existingAccessory.displayName);
+    _unregisterExistingAccessory(existingAccessory, log) {
+        if (log === true) {
+            this.platform.log.info('Removing existing accessory from cache:', existingAccessory.displayName);
+        }
 
         this.platform.api.unregisterPlatformAccessories(
             settings.PLUGIN_NAME,

--- a/src/platform.js
+++ b/src/platform.js
@@ -163,6 +163,20 @@ class Platform {
             );
         }
 
+        // Vertical airflow direction
+        if (this.config.enableVerticalAirflowDirection) {
+            this.accessoryManager.registerVerticalAirflowDirectionAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterVerticalAirflowDirectionAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
         // "Dry Mode" switch
         if (this.config.enableDryModeSwitch) {
             this.accessoryManager.registerDryModeSwitchAccessory(

--- a/src/platform.js
+++ b/src/platform.js
@@ -150,18 +150,11 @@ class Platform {
         }
 
         // Vertical slats
-        if (this.config.enableVerticalSlats) {
-            this.accessoryManager.registerVerticalSlatsAccessory(
-                deviceId,
-                deviceName,
-                model
-            );
-        } else {
-            this.accessoryManager.unregisterVerticalSlatsAccessory(
-                deviceId,
-                deviceName
-            );
-        }
+        // Currently disabled since Apple Home doesn't support Slats service
+        this.accessoryManager.unregisterVerticalSlatsAccessory(
+            deviceId,
+            deviceName
+        );
 
         // Vertical airflow direction
         if (this.config.enableVerticalAirflowDirection) {

--- a/test/test-platform-accessory-manager.js
+++ b/test/test-platform-accessory-manager.js
@@ -224,23 +224,67 @@ test('PlatformAccessoryManager#registerVerticalSlatsAccessory registers new acce
     resetMocks();
 });
 
-test('PlatformAccessoryManager#registerVerticalSlatsAccessory registers existing accessory', (context) => {
+test('PlatformAccessoryManager#registerVerticalAirflowDirectionAccessory registers existing accessory', (context) => {
     const existingUuid = hap.uuid.generate(
-        deviceId + '-vertical-slats'
+        deviceId + '-vertical-airflow-direction'
     );
     const existingPlatformAccessory = new MockPlatformAccessory(
-        'Test Device Vertical Slats',
+        'Test Device Vertical Airflow Direction',
         existingUuid
     );
     mockPlatform.accessories = [existingPlatformAccessory];
 
-    platformAccessoryManager.registerVerticalSlatsAccessory(deviceId, deviceName, deviceModel);
+    platformAccessoryManager.registerVerticalAirflowDirectionAccessory(deviceId, deviceName, deviceModel);
 
     const mockedMethod = mockPlatform.api.updatePlatformAccessories.mock;
     assert.strictEqual(mockedMethod.calls.length, 1);
     const mockPlatformAccessory = mockedMethod.calls[0].arguments[0][0];
     assert.strictEqual(mockPlatformAccessory, existingPlatformAccessory);
-    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Vertical Slats');
+    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Vertical Airflow Direction');
+    assert.strictEqual(mockPlatformAccessory.context.airstageClient, airstageClient);
+    assert.strictEqual(mockPlatformAccessory.context.deviceId, deviceId);
+    assert.strictEqual(mockPlatformAccessory.context.model, deviceModel);
+    assert.strictEqual(mockPlatform.accessories.length, 1);
+    assert.strictEqual(mockPlatform.accessories[0], mockPlatformAccessory);
+
+    resetMocks();
+});
+
+test('PlatformAccessoryManager#registerVerticalAirflowDirectionAccessory registers new accessory', (context) => {
+    platformAccessoryManager.registerVerticalAirflowDirectionAccessory(deviceId, deviceName, deviceModel);
+
+    const mockedMethod = mockPlatform.api.registerPlatformAccessories.mock;
+    assert.strictEqual(mockedMethod.calls.length, 1);
+    assert.strictEqual(mockedMethod.calls[0].arguments[0], settings.PLUGIN_NAME);
+    assert.strictEqual(mockedMethod.calls[0].arguments[1], settings.PLATFORM_NAME);
+    const mockPlatformAccessory = mockedMethod.calls[0].arguments[2][0];
+    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Vertical Airflow Direction');
+    assert.strictEqual(mockPlatformAccessory.context.airstageClient, airstageClient);
+    assert.strictEqual(mockPlatformAccessory.context.deviceId, deviceId);
+    assert.strictEqual(mockPlatformAccessory.context.model, deviceModel);
+    assert.strictEqual(mockPlatform.accessories.length, 1);
+    assert.strictEqual(mockPlatform.accessories[0], mockPlatformAccessory);
+
+    resetMocks();
+});
+
+test('PlatformAccessoryManager#registerDryModeSwitchAccessory registers existing accessory', (context) => {
+    const existingUuid = hap.uuid.generate(
+        deviceId + '-dry-mode-switch'
+    );
+    const existingPlatformAccessory = new MockPlatformAccessory(
+        'Test Device Dry Mode Switch',
+        existingUuid
+    );
+    mockPlatform.accessories = [existingPlatformAccessory];
+
+    platformAccessoryManager.registerDryModeSwitchAccessory(deviceId, deviceName, deviceModel);
+
+    const mockedMethod = mockPlatform.api.updatePlatformAccessories.mock;
+    assert.strictEqual(mockedMethod.calls.length, 1);
+    const mockPlatformAccessory = mockedMethod.calls[0].arguments[0][0];
+    assert.strictEqual(mockPlatformAccessory, existingPlatformAccessory);
+    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Dry Mode Switch');
     assert.strictEqual(mockPlatformAccessory.context.airstageClient, airstageClient);
     assert.strictEqual(mockPlatformAccessory.context.deviceId, deviceId);
     assert.strictEqual(mockPlatformAccessory.context.model, deviceModel);
@@ -543,6 +587,28 @@ test('PlatformAccessoryManager#unregisterVerticalSlatsAccessory unregisters exis
     mockPlatform.accessories = [existingPlatformAccessory];
 
     platformAccessoryManager.unregisterVerticalSlatsAccessory(deviceId, deviceName);
+
+    const mockedMethod = mockPlatform.api.unregisterPlatformAccessories.mock;
+    assert.strictEqual(mockedMethod.calls.length, 1);
+    assert.strictEqual(mockedMethod.calls[0].arguments[0], settings.PLUGIN_NAME);
+    assert.strictEqual(mockedMethod.calls[0].arguments[1], settings.PLATFORM_NAME);
+    const mockPlatformAccessory = mockedMethod.calls[0].arguments[2][0];
+    assert.strictEqual(mockPlatformAccessory, existingPlatformAccessory);
+
+    resetMocks();
+});
+
+test('PlatformAccessoryManager#unregisterVerticalAirflowDirectionAccessory unregisters existing accessory', (context) => {
+    const existingUuid = hap.uuid.generate(
+        deviceId + '-vertical-airflow-direction'
+    );
+    const existingPlatformAccessory = new MockPlatformAccessory(
+        'Test Device Vertical Airflow Direction',
+        existingUuid
+    );
+    mockPlatform.accessories = [existingPlatformAccessory];
+
+    platformAccessoryManager.unregisterVerticalAirflowDirectionAccessory(deviceId, deviceName);
 
     const mockedMethod = mockPlatform.api.unregisterPlatformAccessories.mock;
     assert.strictEqual(mockedMethod.calls.length, 1);


### PR DESCRIPTION
Since Apple Home doesn't currently support the "Slats" service being used in `VerticalSlatsAccessory`, this PR adds `VerticalAirflowDirectionAccessory`, which uses the "Fanv2" service to control the vertical slats (via the "Rotation Speed" characteristic).