### PR TITLE
Update device, user metadata cache without resetting it

### DIFF
--- a/src/platform.js
+++ b/src/platform.js
@@ -268,10 +268,7 @@ class Platform {
     }
 
     _refreshAirstageClientCache() {
-        const limit = 100;
-
-        this.airstageClient.resetUserMetadataCache();
-        this.airstageClient.getUserMetadata(
+        this.airstageClient.refreshUserMetadataCache(
             (function(error) {
                 if (error) {
                     return this.log.error('Error when attempting to communicate with Airstage:', error);
@@ -279,9 +276,7 @@ class Platform {
 
                 this.log.debug('Refreshed Airstage client user metadata cache');
 
-                this.airstageClient.resetDeviceCache();
-                this.airstageClient.getDevices(
-                    limit,
+                this.airstageClient.refreshDeviceCache(
                     (function(error, devices) {
                         if (error) {
                             return this.log.error('Error when attempting to communicate with Airstage:', error);


### PR DESCRIPTION
Add and use `refreshUserMetadataCache` and `refreshDeviceCache` to the Airstage client. This allows you to update the cache without completely clearing it first, which prevents race conditions where the cache is being updated, and something attempts to read from it before it is updated.