### PR TITLE
Update access token refresh handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ point, they will be set to `null`, and the `accessToken`, `accessTokenExpiry`,
 and `refreshToken` values will be set. These values will be used to authenticate
 with the Airstage API going forward.
 
+If the access token can't be refreshed for whatever reason, you will have to
+re-authenticate with the Airstage API by setting `email` and `password` in the
+config, and restarting Homebridge.
+
 ## Accessories
 
 For each device in your Airstage account, this plugin offers several

--- a/src/config-manager.js
+++ b/src/config-manager.js
@@ -13,12 +13,17 @@ class ConfigManager {
         const homebridgeConfigPath = this.api.user.configPath();
         const homebridgeConfigString = this._readFileSync(homebridgeConfigPath);
         let homebridgeConfig = JSON.parse(homebridgeConfigString);
+        let accessTokenExpiryISO = null;
+
+        if (accessTokenExpiry !== null) {
+            accessTokenExpiryISO = accessTokenExpiry.toISOString();
+        }
 
         this.config.email = null;
         this.config.password = null;
 
         this.config.accessToken = accessToken;
-        this.config.accessTokenExpiry = accessTokenExpiry.toISOString();
+        this.config.accessTokenExpiry = accessTokenExpiryISO;
         this.config.refreshToken = refreshToken;
 
         homebridgeConfig.platforms.some(function(platformConfig, idx, platforms) {

--- a/src/platform.js
+++ b/src/platform.js
@@ -65,6 +65,10 @@ class Platform {
                     callback(error);
                 }
 
+                if (error === 'Invalid access token') {
+                    this._unsetAccessTokenInConfig();
+                }
+
                 return this.log.error('Error when attempting to authenticate with Airstage:', error);
             }
 
@@ -87,6 +91,10 @@ class Platform {
 
             this.log.debug('Updated config with Airstage client token');
         }
+    }
+
+    _unsetAccessTokenInConfig() {
+        this.configManager.updateConfigWithAccessToken(null, null, null);
     }
 
     _configureAirstageDevices(callback) {

--- a/src/platform.js
+++ b/src/platform.js
@@ -47,7 +47,7 @@ class Platform {
 
             setInterval(
                 this._refreshAirstageClientToken.bind(this),
-                (58 * 60 * 1000) // 58 minutes
+                (50 * 60 * 1000) // 50 minutes
             );
         }
 


### PR DESCRIPTION
- Better handle access token refresh failures by unsetting the access token values in the config
- Attempt to refresh the access token every 50 minutes, instead of 58 minutes
- Update the README