### PR TITLE
Add support for Homebridge 2

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "homebridge-fujitsu-airstage",
-  "version": "1.0.7",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-fujitsu-airstage",
-      "version": "1.0.7",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.12.13",
         "homebridge": "^1.7.0"
       },
       "engines": {
-        "homebridge": "^1.7.0",
-        "node": "^18.17.0 || ^20.9.0"
+        "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+        "node": "^18.20.4 || ^20.15.1 || ^22"
       },
       "funding": {
         "type": "venmo",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "src/index.js",
   "scripts": {
-      "test": "node --test --experimental-test-coverage test/"
+      "test": "node --test --experimental-test-coverage"
   },
   "funding": {
       "type": "venmo",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/PatrickStankard/homebridge-fujitsu-airstage/issues"
   },
   "engines": {
-    "node": "^18.17.0 || ^20.9.0",
-    "homebridge": "^1.7.0"
+    "node": "^18.20.4 || ^20.15.1 || ^22",
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0"
   },
   "main": "src/index.js",
   "scripts": {
@@ -26,7 +26,10 @@
   },
   "keywords": [
     "homebridge",
-    "homebridge-plugin"
+    "homebridge-plugin",
+    "fujitsu",
+    "airstage",
+    "thermostat"
   ],
   "devDependencies": {
     "@types/node": "^20.12.13",


### PR DESCRIPTION
Based on the [docs for updating to Homebridge 2](https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0), I tested the plugin on the latest beta (`v2.0.0-beta.27`), and it didn't break. This PR updates `node` and `homebridge` in the `package.json` to the versions specified in the docs.