### PR TITLE
Feat: Secure Credential Storage + Child Bridge Init Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Before using this, you should have already installed the
 [Airstage app](https://www.fujitsugeneral.com/us/airstage-mobile/setup.html) on
 your iOS or Android device, signed up for an account, and configured your devices.
 
+## Homebridge Compatibility
+
+- Supports Homebridge v1 and v2 (including child bridge mode)
+- Tokens and authentication data are managed automatically using the Homebridge v2 storage API when available
+- No manual editing of tokens is required or supported
+- Homebridge UI configuration is improved and user-friendly
+
 ## Configuration
 
 The easiest way to configure this plugin is to use
@@ -33,9 +40,6 @@ installed and configured this plugin:
             "email": "test@example.com",
             "password": "test1234",
             "rememberEmailAndPassword": false,
-            "accessToken": null,
-            "accessTokenExpiry": null,
-            "refreshToken": null,
             "enableThermostat": true,
             "enableFan": true,
             "enableVerticalAirflowDirection": false,
@@ -62,9 +66,8 @@ been completed successfully. This is useful for when the access token can't be
 refreshed for whatever reason, and you need to re-authenticate with the
 Airstage API.
 
-Once authentication with the Airstage API has been completed successfully,
-the `accessToken`, `accessTokenExpiry`, and `refreshToken` values will be set.
-These values will be used to authenticate with the Airstage API going forward.
+**Note:**
+- You do **not** need to set or manage `accessToken`, `accessTokenExpiry`, or `refreshToken` in your config. These are handled automatically by the plugin and are no longer shown in the Homebridge UI.
 
 ## Accessories
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ Airstage API.
 **Note:**
 - You do **not** need to set or manage `accessToken`, `accessTokenExpiry`, or `refreshToken` in your config. These are handled automatically by the plugin and are no longer shown in the Homebridge UI.
 
+## Secure Secret Storage
+
+This plugin securely stores all tokens and sensitive credentials using strong encryption. Secrets are never stored in plaintext.
+
+Encryption uses AES-256-GCM with a key derived via PBKDF2 (100,000 iterations, SHA-512) and a salt based on a SHA-256 hash of unique values. The encrypted file is stored with strict permissions (0600) and is not exposed in the Homebridge UI or config.
+
+**You do not need to manage or back up tokens or passwords manually.**
+
+If you move your Homebridge instance to a new machine or change the setup ID, you will need to re-authenticate, as the encrypted secrets are only accessible on the original installation.
+
+---
+
 ## Accessories
 
 For each device in your Airstage account, this plugin offers several

--- a/config.schema.json
+++ b/config.schema.json
@@ -9,7 +9,8 @@
                 "title": "Name",
                 "type": "string",
                 "default": "Airstage Platform",
-                "required": true
+                "required": true,
+                "description": "The display name for this platform instance."
             },
             "region": {
                 "title": "Region",
@@ -25,30 +26,35 @@
                         "title": "Europe",
                         "const": "eu"
                     }
-                ]
+                ],
+                "description": "The region for your Airstage account (us or eu)."
             },
             "country": {
                 "title": "Country",
                 "type": "string",
                 "required": true,
-                "default": "United States"
+                "default": "United States",
+                "description": "The country associated with your Airstage account."
             },
             "language": {
                 "title": "Language",
                 "type": "string",
                 "required": true,
-                "default": "en"
+                "default": "en",
+                "description": "The language code for your Airstage account (e.g., 'en')."
             },
             "email": {
                 "title": "Airstage Email",
                 "type": "string",
                 "format": "email",
-                "default": ""
+                "default": "",
+                "description": "The email address for your Airstage account."
             },
             "password": {
                 "title": "Airstage Password",
                 "type": "string",
-                "default": ""
+                "default": "",
+                "description": "The password for your Airstage account."
             },
             "rememberEmailAndPassword": {
                 "title": "Remember Airstage Email and Password",
@@ -56,68 +62,59 @@
                 "default": false,
                 "description": "If enabled, the Airstage email and password will be stored in the config after a successful authentication with the Airstage API."
             },
-            "accessToken": {
-                "title": "Airstage Access Token",
-                "type": "string",
-                "default": "",
-                "description": "This will be automatically be set after a successful authentication with the Airstage API."
-            },
-            "accessTokenExpiry": {
-                "title": "Airstage Access Token Expiry",
-                "type": "string",
-                "default": "",
-                "description": "This will be automatically be set after a successful authentication with the Airstage API."
-            },
-            "refreshToken": {
-                "title": "Airstage Refresh Token",
-                "type": "string",
-                "default": "",
-                "description": "This will be automatically be set after a successful authentication with the Airstage API."
-            },
             "enableThermostat": {
                 "title": "Enable thermostat control",
                 "type": "boolean",
-                "default": true
+                "default": true,
+                "description": "Enable or disable the thermostat accessory for your devices."
             },
             "enableFan": {
                 "title": "Enable fan control",
                 "type": "boolean",
-                "default": true
+                "default": true,
+                "description": "Enable or disable the fan accessory for your devices."
             },
             "enableVerticalAirflowDirection": {
                 "title": "Enable vertical airflow direction control",
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "Enable or disable the vertical airflow direction accessory."
             },
             "enableDryModeSwitch": {
                 "title": "Enable 'Dry Mode' switch",
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "Enable or disable the 'Dry Mode' switch accessory."
             },
             "enableEconomySwitch": {
                 "title": "Enable 'Economy' switch",
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "Enable or disable the 'Economy' switch accessory."
             },
             "enableEnergySavingFanSwitch": {
                 "title": "Enable 'Energy Saving Fan' switch",
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "Enable or disable the 'Energy Saving Fan' switch accessory."
             },
             "enableFanModeSwitch": {
                 "title": "Enable 'Fan Mode' switch",
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "Enable or disable the 'Fan Mode' switch accessory."
             },
             "enableMinimumHeatModeSwitch": {
                 "title": "Enable 'Minimum Heat Mode' switch",
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "Enable or disable the 'Minimum Heat Mode' switch accessory."
             },
             "enablePowerfulSwitch": {
                 "title": "Enable 'Powerful' switch",
                 "type": "boolean",
-                "default": false
+                "default": false,
+                "description": "Enable or disable the 'Powerful' switch accessory."
             }
         }
     }

--- a/config.schema.json
+++ b/config.schema.json
@@ -60,7 +60,7 @@
                 "title": "Remember Airstage Email and Password",
                 "type": "boolean",
                 "default": false,
-                "description": "If enabled, the Airstage email and password will be stored in the config after a successful authentication with the Airstage API."
+                "description": "If enabled, the Airstage email and password will be stored securely after a successful authentication with the Airstage API."
             },
             "enableThermostat": {
                 "title": "Enable thermostat control",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.12.13",
-        "homebridge": "^1.7.0"
+        "@types/node": "^22",
+        "homebridge": "^1.9.0"
       },
       "engines": {
         "homebridge": "^1.6.0 || ^2.0.0-beta.0",
@@ -22,22 +22,22 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.2.0.tgz",
-      "integrity": "sha512-2Qa8MVC7Q5DKH6iXh6cRvqz9VJYVpVZ+whHKrnr8YdPkXxc67kiQ9IOxMb0ydokDTETBVyXgr1m+HrheBtqDoQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.1.tgz",
+      "integrity": "sha512-87tQCBNNnTymlbg8pKlQjRsk7a5uuqhWBpCbUriVYUebz3voJkLbbTmp0TQg7Sa6Jnpk/Uo6LA8zAOy2sbK9bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.4",
+        "debug": "^4.3.6",
         "fast-deep-equal": "^3.1.3",
         "source-map-support": "^0.5.21",
-        "tslib": "^2.6.2"
+        "tslib": "^2.6.3"
       },
       "bin": {
         "ciao-bcs": "lib/bonjour-conformance-testing.js"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^18 || ^20 || ^22"
       }
     },
     "node_modules/@homebridge/dbus-native": {
@@ -84,13 +84,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "version": "22.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
+      "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -110,14 +110,14 @@
       }
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
-        "is-array-buffer": "^3.0.4"
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
       },
       "engines": {
         "node": ">= 0.4"
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/array-flatten": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
       "dev": true,
       "license": "MIT"
     },
@@ -150,13 +150,13 @@
       }
     },
     "node_modules/bonjour-hap": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.7.2.tgz",
-      "integrity": "sha512-BzOdOSIpXqjE1hejVNhj1T7E5YazPNG7cMOph5jQfzf1nF2yO18FSxuIg2zDMa4tFxhNC5d+U+0hT2bQkC5nTw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.9.0.tgz",
+      "integrity": "sha512-g/25iC9U3vYCwR8NvspPJhsl8kNgVSsXPbgAFO/+Gm0x6kn33XCL6CMvg79ZViAAo0NZRHqa5VR52eUw1zE2IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "array-flatten": "^2.1.2",
+        "array-flatten": "^3.0.0",
         "deep-equal": "^2.2.3",
         "multicast-dns": "^7.2.5",
         "multicast-dns-service-types": "^1.1.0"
@@ -170,17 +170,47 @@
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -227,9 +257,9 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
-      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -237,13 +267,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -336,6 +366,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -344,14 +389,11 @@
       "license": "MIT"
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -385,6 +427,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/event-stream": {
@@ -421,13 +476,19 @@
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/from": {
@@ -438,9 +499,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -483,17 +544,22 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -502,14 +568,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/gopd": {
+    "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.1.3"
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -523,33 +603,36 @@
       "license": "ISC"
     },
     "node_modules/hap-nodejs": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.12.1.tgz",
-      "integrity": "sha512-iUUMaK6ucDKLMjT4m5Oz6CoLKkGg+omI6GR96weyL8fPGR1HYoCMtoJoUNW2NSIp4b2A6hx4zjNOEtLEaTA2MQ==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.12.3.tgz",
+      "integrity": "sha512-E6uEwSmDejvzaSAHosjjbWp7/YNo0o+LZtcbH2KoediVOHGG1tYRDGEMyOiG7ZtZn6CwXwr6xqSZTnXTzQCImQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/ciao": "^1.2.0",
+        "@homebridge/ciao": "^1.3.1",
         "@homebridge/dbus-native": "^0.6.0",
-        "bonjour-hap": "^3.7.2",
-        "debug": "^4.3.4",
+        "bonjour-hap": "^3.8.0",
+        "debug": "^4.3.7",
         "fast-srp-hap": "^2.0.4",
         "futoin-hkdf": "^1.5.3",
-        "node-persist": "^0.0.11",
+        "node-persist": "^0.0.12",
         "source-map-support": "^0.5.21",
-        "tslib": "^2.6.2",
+        "tslib": "^2.8.0",
         "tweetnacl": "^1.0.3"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^18 || ^20 || ^22"
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -577,23 +660,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -646,51 +716,51 @@
       }
     },
     "node_modules/homebridge": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.8.2.tgz",
-      "integrity": "sha512-K0P9/qk3RdAKGLhGrmtF4skUjcygNlnBu0S/ssKIdp4p0kMzW2wjw2Q+z7TCxgZVy84/kaR09UD1n6uJAunTOQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.9.0.tgz",
+      "integrity": "sha512-h8E/6VODsl8M0pDwf/Lu58iI6WzfAMbcOneISGpKS16jf2Sl7yP4c6pfFNPYY/fxwkWuHUlb5mUaZy4xEvb7LQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "4.1.2",
-        "commander": "12.0.0",
-        "fs-extra": "11.2.0",
-        "hap-nodejs": "0.12.1",
+        "commander": "13.1.0",
+        "fs-extra": "11.3.0",
+        "hap-nodejs": "0.12.3",
         "qrcode-terminal": "0.12.0",
-        "semver": "7.6.2",
+        "semver": "7.7.1",
         "source-map-support": "0.5.21"
       },
       "bin": {
         "homebridge": "bin/homebridge"
       },
       "engines": {
-        "node": "^18.15.0 || ^20.7.0"
+        "node": "^18.15.0 || ^20.7.0 || ^22"
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -700,14 +770,15 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -717,27 +788,30 @@
       }
     },
     "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-bigints": "^1.0.1"
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -760,13 +834,14 @@
       }
     },
     "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -789,13 +864,14 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -805,14 +881,16 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -835,13 +913,13 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "call-bound": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -851,13 +929,14 @@
       }
     },
     "node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -867,13 +946,15 @@
       }
     },
     "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -896,14 +977,14 @@
       }
     },
     "node_modules/is-weakset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-      "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "get-intrinsic": "^1.2.4"
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -939,6 +1020,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -963,9 +1054,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -991,9 +1082,9 @@
       "license": "MIT"
     },
     "node_modules/node-persist": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.11.tgz",
-      "integrity": "sha512-J3EPzQDgPxPBID7TqHSd5KkpTULFqJUvYDoISfOWg9EihpeVCH3b6YQeDeubzVuc4e6+aiVmkz2sdkWI4K+ghA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-0.0.12.tgz",
+      "integrity": "sha512-Fbia3FYnURzaql53wLu0t19dmAwQg/tXT6O7YPmdwNwysNKEyFmgoT2BQlPD3XXQnYeiQVNvR5lfvufGwKuxhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1002,11 +1093,14 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1039,15 +1133,17 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -1071,9 +1167,9 @@
       }
     },
     "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1102,16 +1198,18 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
-      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-errors": "^1.3.0",
-        "set-function-name": "^2.0.1"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1141,6 +1239,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/sax": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
@@ -1149,9 +1265,9 @@
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1196,16 +1312,73 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1249,13 +1422,14 @@
       }
     },
     "node_modules/stop-iteration-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "internal-slot": "^1.0.4"
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1300,9 +1474,9 @@
       "license": "MIT"
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },
@@ -1314,9 +1488,9 @@
       "license": "Unlicense"
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1331,17 +1505,20 @@
       }
     },
     "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1367,16 +1544,18 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "thermostat"
   ],
   "devDependencies": {
-    "@types/node": "^20.12.13",
-    "homebridge": "^1.7.0"
+    "@types/node": "^22",
+    "homebridge": "^1.9.0"
   },
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/PatrickStankard/homebridge-fujitsu-airstage/issues"
   },
   "engines": {
-    "node": "^18.20.4 || ^20.15.1 || ^22",
+    "node": "^18 || ^20 || ^22",
     "homebridge": "^1.6.0 || ^2.0.0-beta.0"
   },
   "main": "src/index.js",

--- a/src/config-manager.js
+++ b/src/config-manager.js
@@ -197,3 +197,8 @@ class ConfigManager {
 }
 
 module.exports = ConfigManager;
+// Export helpers for testing/coverage only
+module.exports.getSetupID = getSetupID;
+module.exports.getEncryptionKey = getEncryptionKey;
+module.exports.encrypt = encrypt;
+module.exports.decrypt = decrypt;

--- a/src/config-manager.js
+++ b/src/config-manager.js
@@ -1,14 +1,85 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 class ConfigManager {
-
     constructor(config, api) {
         this.api = api;
         this.config = config;
+        this.persistFile = path.join(this.api.user.persistPath(), 'airstage-tokens.json');
     }
 
+    // Save tokens and password to persistPath (secure, not exposed in UI)
+    saveTokensToPersistPath(accessToken, accessTokenExpiry, refreshToken, password = null) {
+        const tokens = {
+            accessToken,
+            accessTokenExpiry: accessTokenExpiry ? accessTokenExpiry.toISOString() : null,
+            refreshToken
+        };
+        // Only persist password if rememberEmailAndPassword is true
+        if (this.config.rememberEmailAndPassword && password) {
+            tokens.password = password;
+        }
+        try {
+            fs.writeFileSync(this.persistFile, JSON.stringify(tokens, null, 2), { mode: 0o600 });
+        } catch (err) {
+            if (this.api && this.api.logger) {
+                this.api.logger.error('Failed to write Airstage tokens to persistPath:', err.message);
+            }
+        }
+    }
+
+    // Retrieve tokens and password from persistPath
+    getTokensFromPersistPath() {
+        try {
+            if (fs.existsSync(this.persistFile)) {
+                const data = fs.readFileSync(this.persistFile, 'utf8');
+                const tokens = JSON.parse(data);
+                return {
+                    accessToken: tokens.accessToken || null,
+                    accessTokenExpiry: tokens.accessTokenExpiry ? new Date(tokens.accessTokenExpiry) : null,
+                    refreshToken: tokens.refreshToken || null,
+                    password: tokens.password || null
+                };
+            }
+        } catch (err) {
+            if (this.api && this.api.logger) {
+                this.api.logger.error('Failed to read Airstage tokens from persistPath:', err.message);
+            }
+        }
+        return { accessToken: null, accessTokenExpiry: null, refreshToken: null, password: null };
+    }
+
+    // Save tokens (main entry point)
+    async saveTokens(accessToken, accessTokenExpiry, refreshToken, password = null) {
+        this.saveTokensToPersistPath(accessToken, accessTokenExpiry, refreshToken, password);
+    }
+
+    // Retrieve tokens (main entry point)
+    async getTokens() {
+        // Try persistPath first
+        const tokens = this.getTokensFromPersistPath();
+        if (tokens.accessToken || tokens.refreshToken) {
+            return tokens;
+        }
+        // Fallback: migrate from config if present
+        const accessToken = this.config.accessToken || null;
+        const accessTokenExpiry = this.config.accessTokenExpiry ? new Date(this.config.accessTokenExpiry) : null;
+        const refreshToken = this.config.refreshToken || null;
+        let password = null;
+        if (this.config.rememberEmailAndPassword && this.config.password) {
+            password = this.config.password;
+        }
+        if (accessToken || refreshToken) {
+            // Migrate to persistPath
+            this.saveTokensToPersistPath(accessToken, accessTokenExpiry, refreshToken, password);
+            return { accessToken, accessTokenExpiry, refreshToken, password };
+        }
+        return { accessToken: null, accessTokenExpiry: null, refreshToken: null, password: null };
+    }
+
+    // Deprecated: Only for legacy Homebridge v1 fallback
     updateConfigWithAccessToken(accessToken, accessTokenExpiry, refreshToken) {
         // Only used for Homebridge v1 fallback
         const homebridgeConfigPath = this.api.user.configPath();
@@ -42,40 +113,6 @@ class ConfigManager {
             return true;
         }
         return false;
-    }
-
-    // Save tokens using Homebridge v2 storage API
-    async saveTokensToStorage(accessToken, accessTokenExpiry, refreshToken) {
-        const tokens = {
-            accessToken,
-            accessTokenExpiry: accessTokenExpiry ? accessTokenExpiry.toISOString() : null,
-            refreshToken
-        };
-        if (this.api.storage && typeof this.api.storage.setItem === 'function') {
-            await this.api.storage.setItem('airstage-tokens', tokens);
-        } else {
-            // Homebridge v1 fallback: update config file
-            this.updateConfigWithAccessToken(accessToken, accessTokenExpiry, refreshToken);
-        }
-    }
-
-    // Retrieve tokens using Homebridge v2 storage API
-    async getTokensFromStorage() {
-        if (this.api.storage && typeof this.api.storage.getItem === 'function') {
-            const tokens = await this.api.storage.getItem('airstage-tokens');
-            if (!tokens) return { accessToken: null, accessTokenExpiry: null, refreshToken: null };
-            return {
-                accessToken: tokens.accessToken || null,
-                accessTokenExpiry: tokens.accessTokenExpiry ? new Date(tokens.accessTokenExpiry) : null,
-                refreshToken: tokens.refreshToken || null
-            };
-        } else {
-            // Homebridge v1 fallback: read from config
-            const accessToken = this.config.accessToken || null;
-            const accessTokenExpiry = this.config.accessTokenExpiry ? new Date(this.config.accessTokenExpiry) : null;
-            const refreshToken = this.config.refreshToken || null;
-            return { accessToken, accessTokenExpiry, refreshToken };
-        }
     }
 
     // Deprecated: No longer used in Homebridge v2+

--- a/src/config-manager.js
+++ b/src/config-manager.js
@@ -8,11 +8,11 @@ const settings = require('./settings');
 // Helper: get Homebridge setup ID (returns string or empty if not available)
 function getSetupID(api) {
     try {
-        if (api && api.user && typeof api.user.getSetupId === 'function') {
+        if (api?.user?.getSetupId) {
             return api.user.getSetupId() || '';
         }
         // Homebridge v1 fallback: try configPath file
-        if (api && api.user && typeof api.user.configPath === 'function') {
+        if (api?.user?.configPath) {
             const configPath = api.user.configPath();
             if (fs.existsSync(configPath)) {
                 const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));

--- a/src/config-manager.js
+++ b/src/config-manager.js
@@ -10,14 +10,14 @@ class ConfigManager {
     }
 
     updateConfigWithAccessToken(accessToken, accessTokenExpiry, refreshToken) {
+        // Only used for Homebridge v1 fallback
         const homebridgeConfigPath = this.api.user.configPath();
         const homebridgeConfigString = this._readFileSync(homebridgeConfigPath);
-
         let homebridgeConfig = JSON.parse(homebridgeConfigString);
         let accessTokenExpiryISO = null;
 
-        if (accessTokenExpiry !== null) {
-            accessTokenExpiryISO = accessTokenExpiry.toISOString();
+        if (accessTokenExpiry !== null && accessTokenExpiry !== undefined) {
+            accessTokenExpiryISO = accessTokenExpiry instanceof Date ? accessTokenExpiry.toISOString() : accessTokenExpiry;
         }
 
         if (this.config.rememberEmailAndPassword === false) {
@@ -32,22 +32,53 @@ class ConfigManager {
         homebridgeConfig.platforms.some(function(platformConfig, idx, platforms) {
             if (platformConfig.platform === this.config.platform) {
                 platforms[idx] = this.config;
-
                 return true;
             }
         }, this);
 
         const updatedConfigString = JSON.stringify(homebridgeConfig, null, 4);
-
         if (updatedConfigString !== homebridgeConfigString) {
             this._writeFileSync(homebridgeConfigPath, updatedConfigString);
-
             return true;
         }
-
         return false;
     }
 
+    // Save tokens using Homebridge v2 storage API
+    async saveTokensToStorage(accessToken, accessTokenExpiry, refreshToken) {
+        const tokens = {
+            accessToken,
+            accessTokenExpiry: accessTokenExpiry ? accessTokenExpiry.toISOString() : null,
+            refreshToken
+        };
+        if (this.api.storage && typeof this.api.storage.setItem === 'function') {
+            await this.api.storage.setItem('airstage-tokens', tokens);
+        } else {
+            // Homebridge v1 fallback: update config file
+            this.updateConfigWithAccessToken(accessToken, accessTokenExpiry, refreshToken);
+        }
+    }
+
+    // Retrieve tokens using Homebridge v2 storage API
+    async getTokensFromStorage() {
+        if (this.api.storage && typeof this.api.storage.getItem === 'function') {
+            const tokens = await this.api.storage.getItem('airstage-tokens');
+            if (!tokens) return { accessToken: null, accessTokenExpiry: null, refreshToken: null };
+            return {
+                accessToken: tokens.accessToken || null,
+                accessTokenExpiry: tokens.accessTokenExpiry ? new Date(tokens.accessTokenExpiry) : null,
+                refreshToken: tokens.refreshToken || null
+            };
+        } else {
+            // Homebridge v1 fallback: read from config
+            const accessToken = this.config.accessToken || null;
+            const accessTokenExpiry = this.config.accessTokenExpiry ? new Date(this.config.accessTokenExpiry) : null;
+            const refreshToken = this.config.refreshToken || null;
+            return { accessToken, accessTokenExpiry, refreshToken };
+        }
+    }
+
+    // Deprecated: No longer used in Homebridge v2+
     _readFileSync(path) {
         return fs.readFileSync(path).toString();
     }

--- a/src/platform.js
+++ b/src/platform.js
@@ -27,7 +27,7 @@ class Platform {
         // Synchronous initialization for tests and legacy Homebridge v1
         let tokens = { accessToken: null, accessTokenExpiry: null, refreshToken: null };
         let canSyncInit = true;
-        if (this.api.storage && typeof this.api.storage.getItem === 'function') {
+        if (this.api?.storage?.getItem) {
             // Homebridge v2+ with storage API: cannot synchronously load tokens
             canSyncInit = false;
         }
@@ -124,22 +124,18 @@ class Platform {
         // Only persist password if rememberEmailAndPassword is true
         const password = (this.config.rememberEmailAndPassword ? (this.config.password || null) : null);
         if (accessToken && accessTokenExpiry && refreshToken) {
-            if (typeof this.configManager.saveTokens === 'function') {
-                this.configManager.saveTokens(
-                    accessToken,
-                    accessTokenExpiry,
-                    refreshToken,
-                    password
-                );
-            }
+            this.configManager.saveTokens(
+                accessToken,
+                accessTokenExpiry,
+                refreshToken,
+                password
+            );
             this.log.debug('Updated tokens using Homebridge persistPath');
         }
     }
 
     _unsetAccessTokenInConfig() {
-        if (typeof this.configManager.saveTokens === 'function') {
-            this.configManager.saveTokens(null, null, null, null);
-        }
+        this.configManager.saveTokens(null, null, null, null);
         this.log.debug('Unset tokens using Homebridge persistPath');
     }
 

--- a/src/platform.js
+++ b/src/platform.js
@@ -168,7 +168,7 @@ class Platform {
                     const deviceMetadata = devices.metadata[deviceId];
                     const deviceParameters = devices.parameters[deviceId];
                     const deviceName = deviceMetadata.deviceName;
-                    const model = deviceParameters[airstage.apiv1.constants.PARAMETER_MODEL];
+                    const model = deviceParameters[airstage.apiv1.constants.PARAMETER_MODEL] || 'Airstage';
 
                     this._configureAirstageDevice(
                         deviceId,

--- a/src/platform.js
+++ b/src/platform.js
@@ -14,10 +14,10 @@ class Platform {
         this.config = config;
         this.api = api;
         this.accessories = [];
-        this.configManager = new ConfigManager(this.config, this.api);
-        this.accessoryManager = new PlatformAccessoryManager(this);
         this.Service = this.api.hap.Service;
         this.Characteristic = this.api.hap.Characteristic;
+        this.configManager = new ConfigManager(this.config, this.api);
+        this.accessoryManager = new PlatformAccessoryManager(this);
 
         // Polyfill for Homebridge < 1.8.0
         if (!this.log.success) {

--- a/src/test/mock-homebridge.js
+++ b/src/test/mock-homebridge.js
@@ -2,14 +2,20 @@
 
 const { mock } = require('node:test');
 const hap = require('hap-nodejs');
-const PlatformAccessoryManager = require('../platform-accessory-manager');
 const airstage = require('../airstage');
+const PlatformAccessoryManager = require('../platform-accessory-manager');
 
-const airstageClient = new airstage.Client(
-    'us',
-    'United States',
-    'en'
-);
+const airstageClient = new airstage.Client('us', 'United States', 'en');
+
+const mockCharacteristic = {
+    'on': mock.fn((event, listener) => mockCharacteristic),
+    'emit': mock.fn((event, listener) => mockCharacteristic)
+};
+
+const mockService = {
+    'setCharacteristic': mock.fn((name, value) => mockService),
+    'getCharacteristic': mock.fn((name, value) => mockCharacteristic)
+};
 
 class MockPlatformAccessory {
     context = {
@@ -17,39 +23,14 @@ class MockPlatformAccessory {
         'model': 'Test Model',
         'airstageClient': airstageClient
     };
-
     constructor(name, uuid) {
         this.name = name;
         this.uuid = uuid;
         this.UUID = uuid;
     }
-
-    getService(name) {
-        return mockService;
-    }
-
-    addService(name) {
-        return mockService;
-    }
+    getService(name) { return mockService; }
+    addService(name) { return mockService; }
 }
-
-const mockCharacteristic = {
-    'on': mock.fn((event, listener) => {
-        return mockCharacteristic;
-    }),
-    'emit': mock.fn((event, listener) => {
-        return mockCharacteristic;
-    })
-};
-
-const mockService = {
-    'setCharacteristic': mock.fn((name, value) => {
-        return mockService;
-    }),
-    'getCharacteristic': mock.fn((name, value) => {
-        return mockCharacteristic;
-    })
-};
 
 const mockPlatform = {
     'Characteristic': hap.Characteristic,
@@ -60,22 +41,13 @@ const mockPlatform = {
         'hap': hap,
         'platformAccessory': MockPlatformAccessory,
         'user': {
-            'configPath': mock.fn(() => {
-                return '/test/path';
-            })
+            'configPath': mock.fn(() => '/test/path'),
+            'persistPath': mock.fn(() => '/tmp')
         },
-        'updatePlatformAccessories': mock.fn(
-            (accessories) => {}
-        ),
-        'registerPlatformAccessories': mock.fn(
-            (pluginName, platformName, accessories) => {}
-        ),
-        'unregisterPlatformAccessories': mock.fn(
-            (pluginName, platformName, accessories) => {}
-        ),
-        'on': mock.fn((event, listener) => {
-            return mockPlatform.api;
-        })
+        'updatePlatformAccessories': mock.fn(() => {}),
+        'registerPlatformAccessories': mock.fn(() => {}),
+        'unregisterPlatformAccessories': mock.fn(() => {}),
+        'on': mock.fn((event, listener) => mockPlatform.api)
     },
     'log': {
         'debug': mock.fn(() => {}),
@@ -90,7 +62,6 @@ class MockHomebridge {
     characteristic = mockCharacteristic;
     service = mockService;
     platform = mockPlatform;
-
     resetMocks() {
         mockCharacteristic.on.mock.resetCalls();
         mockCharacteristic.emit.mock.resetCalls();

--- a/test/test-config-manager.js
+++ b/test/test-config-manager.js
@@ -8,6 +8,10 @@ const mockApi = {
     'user': {
         'configPath': mock.fn(() => {
             return '/test/path';
+        }),
+        'persistPath': mock.fn(() => {
+            // Use a temp directory for persistPath in tests
+            return '/tmp';
         })
     }
 };

--- a/test/test-config-manager.js
+++ b/test/test-config-manager.js
@@ -165,3 +165,229 @@ test('ConfigManager#updateConfigWithAccessToken does not update the config with 
     assert.strictEqual(configManager._readFileSync.mock.calls[0].arguments[0], '/test/path');
     assert.strictEqual(configManager._writeFileSync.mock.calls.length, 0);
 });
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const settings = require('../src/settings');
+
+// Directly import helpers for coverage
+const _ConfigManager = require('../src/config-manager');
+const _src = require('../src/config-manager.js');
+const { 
+    getSetupID, getEncryptionKey, encrypt, decrypt 
+} = (function() {
+    // Extract helpers from the file
+    const m = require('../src/config-manager');
+    return {
+        getSetupID: m.__getSetupID || require('../src/config-manager').getSetupID || (function() { try { return eval('getSetupID'); } catch { return undefined; } })(),
+        getEncryptionKey: m.__getEncryptionKey || require('../src/config-manager').getEncryptionKey || (function() { try { return eval('getEncryptionKey'); } catch { return undefined; } })(),
+        encrypt: m.__encrypt || require('../src/config-manager').encrypt || (function() { try { return eval('encrypt'); } catch { return undefined; } })(),
+        decrypt: m.__decrypt || require('../src/config-manager').decrypt || (function() { try { return eval('decrypt'); } catch { return undefined; } })(),
+    };
+})();
+
+// Helper to mock fs
+function withTempFile(content, cb) {
+    const tmpFile = path.join('/tmp', 'airstage-tokens-test-' + Date.now() + Math.random());
+    fs.writeFileSync(tmpFile, content);
+    try {
+        return cb(tmpFile);
+    } finally {
+        fs.unlinkSync(tmpFile);
+    }
+}
+
+test('getSetupID returns empty string if api is missing', () => {
+    assert.strictEqual(getSetupID(undefined), '');
+    assert.strictEqual(getSetupID({}), '');
+});
+
+test('getSetupID returns setupId from api.user.getSetupId', () => {
+    const api = { user: { getSetupId: () => 'ABC123' } };
+    assert.strictEqual(getSetupID(api), 'ABC123');
+});
+
+test('getSetupID returns setupID from config file (Homebridge v1 fallback)', () => {
+    const configObj = { bridge: { setupID: 'XYZ789' } };
+    withTempFile(JSON.stringify(configObj), (tmpFile) => {
+        const api = { user: { getSetupId: undefined, configPath: () => tmpFile } };
+        assert.strictEqual(getSetupID(api), 'XYZ789');
+    });
+});
+
+test('getSetupID returns empty string if config file missing or invalid', () => {
+    const api = { user: { getSetupId: undefined, configPath: () => '/tmp/does-not-exist' } };
+    assert.strictEqual(getSetupID(api), '');
+});
+
+test('getEncryptionKey returns a Buffer of length 32', () => {
+    const api = { user: { getSetupId: () => 'SETUPID' } };
+    const key = getEncryptionKey('/tmp', api);
+    assert(Buffer.isBuffer(key));
+    assert.strictEqual(key.length, 32);
+});
+
+test('encrypt and decrypt roundtrip returns original data', () => {
+    const api = { user: { getSetupId: () => 'SETUPID' } };
+    const data = Buffer.from('secret-data', 'utf8');
+    const encrypted = encrypt(data, '/tmp', api);
+    const decrypted = decrypt(encrypted, '/tmp', api);
+    assert.strictEqual(decrypted.toString('utf8'), 'secret-data');
+});
+
+test('decrypt throws on invalid data', () => {
+    const api = { user: { getSetupId: () => 'SETUPID' } };
+    assert.throws(() => decrypt(Buffer.from('short'), '/tmp', api), /Encrypted data too short/);
+});
+
+test('ConfigManager#saveTokensToPersistPath and getTokensFromPersistPath roundtrip', () => {
+    const api = {
+        user: {
+            persistPath: () => '/tmp',
+        },
+        logger: { error: mock.fn() }
+    };
+    const config = { rememberEmailAndPassword: true };
+    const mgr = new _ConfigManager(config, api);
+    const accessToken = 'tok';
+    const accessTokenExpiry = new Date();
+    const refreshToken = 'ref';
+    const password = 'pw';
+    mgr.saveTokensToPersistPath(accessToken, accessTokenExpiry, refreshToken, password);
+    const tokens = mgr.getTokensFromPersistPath();
+    assert.strictEqual(tokens.accessToken, accessToken);
+    assert.strictEqual(tokens.refreshToken, refreshToken);
+    assert.strictEqual(tokens.password, password);
+    assert(tokens.accessTokenExpiry instanceof Date);
+    // Clean up
+    fs.unlinkSync(mgr.persistFile);
+});
+
+test('ConfigManager#getTokensFromPersistPath handles decrypt error', () => {
+    const api = {
+        user: { persistPath: () => '/tmp' },
+        logger: { error: mock.fn() }
+    };
+    const config = {};
+    const mgr = new _ConfigManager(config, api);
+    fs.writeFileSync(mgr.persistFile, Buffer.from('invaliddata'));
+    const tokens = mgr.getTokensFromPersistPath();
+    assert.deepStrictEqual(tokens, { accessToken: null, accessTokenExpiry: null, refreshToken: null, password: null });
+    fs.unlinkSync(mgr.persistFile);
+});
+
+test('ConfigManager#getTokensFromPersistPath returns nulls if file does not exist', () => {
+    const api = { user: { persistPath: () => '/tmp' } };
+    const config = {};
+    const mgr = new _ConfigManager(config, api);
+    if (fs.existsSync(mgr.persistFile)) fs.unlinkSync(mgr.persistFile);
+    const tokens = mgr.getTokensFromPersistPath();
+    assert.deepStrictEqual(tokens, { accessToken: null, accessTokenExpiry: null, refreshToken: null, password: null });
+});
+
+test('ConfigManager#saveTokens calls saveTokensToPersistPath', async () => {
+    const api = { user: { persistPath: () => '/tmp' } };
+    const config = {};
+    const mgr = new _ConfigManager(config, api);
+    let called = false;
+    mgr.saveTokensToPersistPath = () => { called = true; };
+    await mgr.saveTokens('a', new Date(), 'b', 'pw');
+    assert(called);
+});
+
+test('ConfigManager#getTokens migrates from config if persistPath empty', async () => {
+    const api = { user: { persistPath: () => '/tmp' } };
+    const config = { accessToken: 'a', accessTokenExpiry: new Date().toISOString(), refreshToken: 'b', rememberEmailAndPassword: true, password: 'pw' };
+    const mgr = new _ConfigManager(config, api);
+    if (fs.existsSync(mgr.persistFile)) fs.unlinkSync(mgr.persistFile);
+    const tokens = await mgr.getTokens();
+    assert.strictEqual(tokens.accessToken, 'a');
+    assert.strictEqual(tokens.refreshToken, 'b');
+    assert.strictEqual(tokens.password, 'pw');
+    assert(tokens.accessTokenExpiry instanceof Date);
+    fs.unlinkSync(mgr.persistFile);
+});
+
+test('ConfigManager#getTokens returns nulls if nothing present', async () => {
+    const api = { user: { persistPath: () => '/tmp' } };
+    const config = {};
+    const mgr = new _ConfigManager(config, api);
+    if (fs.existsSync(mgr.persistFile)) fs.unlinkSync(mgr.persistFile);
+    const tokens = await mgr.getTokens();
+    assert.deepStrictEqual(tokens, { accessToken: null, accessTokenExpiry: null, refreshToken: null, password: null });
+});
+
+test('ConfigManager#saveTokensToPersistPath handles fs.writeFileSync error', () => {
+    let errorLogged = false;
+    const api = {
+        user: { persistPath: () => '/tmp' },
+        logger: { error: () => { errorLogged = true; } }
+    };
+    const config = { rememberEmailAndPassword: true };
+    const mgr = new _ConfigManager(config, api);
+    const origWrite = fs.writeFileSync;
+    fs.writeFileSync = () => { throw new Error('fail write'); };
+    mgr.saveTokensToPersistPath('a', new Date(), 'b', 'pw');
+    fs.writeFileSync = origWrite;
+    assert.strictEqual(errorLogged, true);
+});
+
+test('ConfigManager#getTokensFromPersistPath handles fs.readFileSync error', () => {
+    let errorLogged = false;
+    const api = {
+        user: { persistPath: () => '/tmp' },
+        logger: { error: () => { errorLogged = true; } }
+    };
+    const config = {};
+    const mgr = new _ConfigManager(config, api);
+    const origRead = fs.readFileSync;
+    fs.readFileSync = () => { throw new Error('fail read'); };
+    // Create file so existsSync is true
+    fs.writeFileSync(mgr.persistFile, Buffer.from('data'));
+    const tokens = mgr.getTokensFromPersistPath();
+    fs.readFileSync = origRead;
+    fs.unlinkSync(mgr.persistFile);
+    assert.strictEqual(errorLogged, true);
+    assert.deepStrictEqual(tokens, { accessToken: null, accessTokenExpiry: null, refreshToken: null, password: null });
+});
+
+test('ConfigManager#saveTokensToPersistPath omits password if rememberEmailAndPassword is false', () => {
+    const api = { user: { persistPath: () => '/tmp' }, logger: { error: mock.fn() } };
+    const config = { rememberEmailAndPassword: false };
+    const mgr = new _ConfigManager(config, api);
+    mgr.saveTokensToPersistPath('a', new Date(), 'b', 'pw');
+    const tokens = mgr.getTokensFromPersistPath();
+    assert.strictEqual(tokens.password, null);
+    fs.unlinkSync(mgr.persistFile);
+});
+
+test('ConfigManager#saveTokensToPersistPath omits password if not provided', () => {
+    const api = { user: { persistPath: () => '/tmp' }, logger: { error: mock.fn() } };
+    const config = { rememberEmailAndPassword: true };
+    const mgr = new _ConfigManager(config, api);
+    mgr.saveTokensToPersistPath('a', new Date(), 'b');
+    const tokens = mgr.getTokensFromPersistPath();
+    assert.strictEqual(tokens.password, null);
+    fs.unlinkSync(mgr.persistFile);
+});
+
+test('ConfigManager#getTokens migrates from config if only refreshToken present', async () => {
+    const api = { user: { persistPath: () => '/tmp' } };
+    const config = { refreshToken: 'b' };
+    const mgr = new _ConfigManager(config, api);
+    if (fs.existsSync(mgr.persistFile)) fs.unlinkSync(mgr.persistFile);
+    const tokens = await mgr.getTokens();
+    assert.strictEqual(tokens.refreshToken, 'b');
+    fs.unlinkSync(mgr.persistFile);
+});
+
+test('ConfigManager#getTokens migrates from config if only accessToken present', async () => {
+    const api = { user: { persistPath: () => '/tmp' } };
+    const config = { accessToken: 'a' };
+    const mgr = new _ConfigManager(config, api);
+    if (fs.existsSync(mgr.persistFile)) fs.unlinkSync(mgr.persistFile);
+    const tokens = await mgr.getTokens();
+    assert.strictEqual(tokens.accessToken, 'a');
+    fs.unlinkSync(mgr.persistFile);
+});


### PR DESCRIPTION
I had initially started out working to resolve an issue that was keeping me from running this plugin as a child bridge. Every time I attempted to do so, Homebridge would restart and the plugin would not come up as a child bridge but still as a basic plugin.

Ultimately I ended up scope-creeping my own changeset and attempting to enhance the security of credential storage.

This PR introduces secure credential management, enhanced compatibility, and improved user config experience. The most notable changes include implementing secure storage for sensitive credentials, removing manual token management, updating the configuration schema with descriptions, and enhancing compatibility with Homebridge v2.

### Secure Token Management and Encryption:
* Introduced secure storage for tokens and sensitive credentials using AES-256-GCM encryption with a key derived via PBKDF2, ensuring secrets are not stored in plaintext. Tokens are now automatically managed and stored securely in the `persistPath` directory. [[1]](diffhunk://#diff-ed9ea1f57d4711b5d69cbd594f118e2d6d855e65ee338ba13411d4f376f4c290R4-R162) [[2]](diffhunk://#diff-ed9ea1f57d4711b5d69cbd594f118e2d6d855e65ee338ba13411d4f376f4c290L35-R189) [[3]](diffhunk://#diff-ed9ea1f57d4711b5d69cbd594f118e2d6d855e65ee338ba13411d4f376f4c290R200-R204)
* Added fallback mechanisms for migrating tokens from older configurations and handling legacy Homebridge v1 setups. [[1]](diffhunk://#diff-b4962c440cbe426deb7709f7f93001a356999830418b32bea9274e5483677129L10-L53) [[2]](diffhunk://#diff-b4962c440cbe426deb7709f7f93001a356999830418b32bea9274e5483677129L84-R143)

### Enhanced Homebridge Compatibility:
* Enhanced support for Homebridge v2, including child bridge mode and the new storage API. Removed legacy methods for token management in the configuration file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R22) [[2]](diffhunk://#diff-b4962c440cbe426deb7709f7f93001a356999830418b32bea9274e5483677129L10-L53)
* Updated `package.json` to reflect compatibility with newer versions of Node.js and Homebridge. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L16-R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R36)

### Improved Configuration Schema:
* Updated `config.schema.json` to include detailed descriptions for all configuration fields, improving clarity for users. Removed deprecated fields such as `accessToken`, `accessTokenExpiry`, and `refreshToken`. [[1]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5L12-R13) [[2]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5L28-R117)

### Documentation Updates:
* Enhanced the `README.md` file to clarify that manual token management is no longer required and to describe the secure storage mechanism. Added a new section for Homebridge compatibility. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R82)

### Codebase Enhancements:
* Fixed bug causing the following warning log when an accessory `Model` could not be determined from Airstage:
    * ```
      [homebridge-fujitsu-airstage] This plugin generated a warning from the characteristic 'Model': [Model] characteristic must have a length of more than 1 character otherwise         HomeKit will reject this accessory, ignoring new value. See https://homebridge.io/w/JtMGR for more info.
      ```
    * Resolved by defaulting any missing Model values to the string `"Airstage"`.
* Refactored `src/config-manager.js` and `src/platform.js` to update token handling, enhance logging, and ensure compatibility with both synchronous and asynchronous initialization. [[1]](diffhunk://#diff-ed9ea1f57d4711b5d69cbd594f118e2d6d855e65ee338ba13411d4f376f4c290R4-R162) [[2]](diffhunk://#diff-b4962c440cbe426deb7709f7f93001a356999830418b32bea9274e5483677129L10-L53)