### PR TITLE
Update access token refresh and reauthentication logic

### DIFF
--- a/src/airstage/apiv1/client.js
+++ b/src/airstage/apiv1/client.js
@@ -308,22 +308,30 @@ class Client {
     }
 
     _storeAccessToken(result) {
+        let accessToken = null;
+        let accessTokenExpiry = null;
+        let refreshToken = null;
+
         if (result.response) {
             if (result.response.accessToken) {
-                this.accessToken = result.response.accessToken;
+                accessToken = result.response.accessToken;
             }
 
             if (result.response.expiresIn) {
-                this.accessTokenExpiry = new Date();
-                this.accessTokenExpiry.setSeconds(
-                    this.accessTokenExpiry.getSeconds() + result.response.expiresIn
+                accessTokenExpiry = new Date();
+                accessTokenExpiry.setSeconds(
+                    accessTokenExpiry.getSeconds() + result.response.expiresIn
                 );
             }
 
             if (result.response.refreshToken) {
-                this.refreshToken = result.response.refreshToken;
+                refreshToken = result.response.refreshToken;
             }
         }
+
+        this.accessToken = accessToken;
+        this.accessTokenExpiry = accessTokenExpiry;
+        this.refreshToken = refreshToken;
     }
 
     _generateDeviceToken() {

--- a/src/airstage/client.js
+++ b/src/airstage/client.js
@@ -36,9 +36,9 @@ class Client {
     }
 
     refreshTokenOrAuthenticate(callback) {
-        if (this._apiClient.accessToken && this._apiClient.refreshToken) {
+        if (this._hasValidAccessToken()) {
             this.refreshToken(callback);
-        } else if (this.email && this.password) {
+        } else if (this._hasValidLoginCredentials()) {
             this.authenticate(callback);
         } else {
             callback('Could not refresh token or authenticate', null);
@@ -938,15 +938,37 @@ class Client {
     }
 
     getAccessToken() {
-        return this._apiClient.accessToken;
+        return this._apiClient.accessToken || null;
     }
 
     getAccessTokenExpiry() {
-        return this._apiClient.accessTokenExpiry;
+        return this._apiClient.accessTokenExpiry || null;
     }
 
     getRefreshToken() {
-        return this._apiClient.refreshToken;
+        return this._apiClient.refreshToken || null;
+    }
+
+    _hasValidLoginCredentials() {
+        return (
+            this._getEmail() !== null &&
+            this._getPassword() !== null
+        );
+    }
+
+    _getEmail() {
+        return this.email || null;
+    }
+
+    _getPassword() {
+        return this.password || null;
+    }
+
+    _hasValidAccessToken() {
+        return (
+            this.getAccessToken() !== null &&
+            this.getAccessTokenExpiry() !== null
+        );
     }
 
     _isInvalidLoginResult(result) {


### PR DESCRIPTION
- Update `_storeAccessToken` in the Airstage API v1 client to store null values if the input `result` doesn't contain valid values
- Add and update getters for email, password, access token values in Airstage client, so that false-y values return null
- Call `refreshTokenOrAuthenticate` instead of `refreshToken` on a schedule in the Platform class, so that we attempt to reauthenticate if the access token is invalid