### PR TITLE
Add "auto fan speed" switch accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ installed and configured this plugin:
             "enableThermostat": true,
             "enableFan": true,
             "enableVerticalAirflowDirection": false,
+            "enableAutoFanSpeedSwitch": false,
             "enableDryModeSwitch": false,
             "enableEconomySwitch": false,
             "enableEnergySavingFanSwitch": false,
@@ -87,6 +88,11 @@ represented in the plugin using the
 
 The fan speed of this accessory represents the position of the vertical slats.
 If the accessory is off, the vertical slats will oscillate.
+
+### "Auto Fan Speed" Switch
+
+This accessory allows you to control the "Auto Fan Speed" setting (on/off) of
+your device.
 
 ### "Dry Mode" Switch
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -77,6 +77,11 @@
                 "type": "boolean",
                 "default": false
             },
+            "enableAutoFanSpeedSwitch": {
+                "title": "Enable 'Auto Fan Speed' switch",
+                "type": "boolean",
+                "default": false
+            },
             "enableDryModeSwitch": {
                 "title": "Enable 'Dry Mode' switch",
                 "type": "boolean",

--- a/src/accessories/auto-fan-speed-switch-accessory.js
+++ b/src/accessories/auto-fan-speed-switch-accessory.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const Accessory = require('./accessory');
+const airstage = require('./../airstage');
+
+class FanModeSwitchAccessory extends Accessory {
+
+    constructor(platform, accessory) {
+        super(platform, accessory);
+
+        this.lastKnownFanSpeed = null;
+
+        this.service = (
+            this.accessory.getService(this.Service.Switch) ||
+            this.accessory.addService(this.Service.Switch)
+        );
+
+        this.service.getCharacteristic(this.Characteristic.On)
+            .on('get', this.getOn.bind(this))
+            .on('set', this.setOn.bind(this));
+
+        this.service.getCharacteristic(this.Characteristic.Name)
+            .on('get', this.getName.bind(this));
+    }
+
+    getOn(callback) {
+        const methodName = this.getOn.name;
+
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
+                let value = null;
+
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (powerState === airstage.constants.TOGGLE_OFF) {
+                    value = false;
+
+                    this._logMethodCallResult(methodName, null, value);
+
+                    return callback(null, value);
+                }
+
+                this.airstageClient.getFanSpeed(
+                    this.deviceId,
+                    (function(error, fanSpeed) {
+                        let value = null;
+
+                        if (error) {
+                            this._logMethodCallResult(methodName, error);
+
+                            return callback(error, null);
+                        }
+
+                        value = (fanSpeed === airstage.constants.FAN_SPEED_AUTO);
+
+                        this._logMethodCallResult(methodName, null, value);
+
+                        callback(null, value);
+                    }).bind(this)
+                );
+            }).bind(this)
+        );
+    }
+
+    setOn(value, callback) {
+        const methodName = this.setOn.name;
+
+        this._logMethodCall(methodName, value);
+
+        let fanSpeed = null;
+
+        if (value) {
+            fanSpeed = airstage.constants.FAN_SPEED_AUTO;
+        } else {
+            if (this.lastKnownFanSpeed !== null) {
+                fanSpeed = this.lastKnownFanSpeed;
+            } else {
+                fanSpeed = airstage.constants.FAN_SPEED_LOW;
+            }
+        }
+
+        this.airstageClient.getPowerState(
+            this.deviceId,
+            (function(error, powerState) {
+                let value = null;
+
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                if (powerState === airstage.constants.TOGGLE_OFF) {
+                    this.airstageClient.setPowerState(
+                        this.deviceId,
+                        airstage.constants.TOGGLE_ON,
+                        (function(error) {
+                            if (error) {
+                                this._logMethodCallResult(methodName, error);
+
+                                return callback(error);
+                            }
+
+                            this._setFanSpeed(
+                                methodName,
+                                fanSpeed,
+                                callback
+                            );
+                        }).bind(this)
+                    );
+                } else {
+                    this._setFanSpeed(
+                        methodName,
+                        fanSpeed,
+                        callback
+                    );
+                }
+            }).bind(this)
+        );
+    }
+
+    getName(callback) {
+        const methodName = this.getName.name;
+
+        this._logMethodCall(methodName);
+
+        this.airstageClient.getName(
+            this.deviceId,
+            (function(error, name) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                const value = name + ' Auto Fan Speed Switch';
+
+                this._logMethodCallResult(methodName, null, value);
+
+                callback(null, value);
+            }).bind(this)
+        );
+    }
+
+    _setFanSpeed(methodName, fanSpeed, callback) {
+        this.airstageClient.getFanSpeed(
+            this.deviceId,
+            (function(error, currentFanSpeed) {
+                if (error) {
+                    this._logMethodCallResult(methodName, error);
+
+                    return callback(error, null);
+                }
+
+                this.lastKnownFanSpeed = currentFanSpeed;
+
+                this.airstageClient.setFanSpeed(
+                    this.deviceId,
+                    fanSpeed,
+                    (function(error) {
+                        if (error) {
+                            this._logMethodCallResult(methodName, error);
+
+                            return callback(error);
+                        }
+
+                        this._logMethodCallResult(methodName, null, null);
+
+                        this._refreshRelatedAccessoryCharacteristics();
+
+                        callback(null);
+                    }).bind(this)
+                );
+            }).bind(this)
+        );
+    }
+
+    _refreshRelatedAccessoryCharacteristics() {
+        const accessoryManager = this.platform.accessoryManager;
+
+        accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshMinimumHeatModeSwitchAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshPowerfulSwitchAccessoryCharacteristics(this.deviceId);
+    }
+}
+
+module.exports = FanModeSwitchAccessory;

--- a/src/accessories/dry-mode-switch-accessory.js
+++ b/src/accessories/dry-mode-switch-accessory.js
@@ -188,6 +188,7 @@ class DryModeSwitchAccessory extends Accessory {
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanModeSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/economy-switch-accessory.js
+++ b/src/accessories/economy-switch-accessory.js
@@ -173,6 +173,7 @@ class EconomySwitchAccessory extends Accessory {
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanModeSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/energy-saving-fan-switch-accessory.js
+++ b/src/accessories/energy-saving-fan-switch-accessory.js
@@ -173,6 +173,7 @@ class EnergySavingFanSwitchAccessory extends Accessory {
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanModeSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -380,6 +380,7 @@ class FanAccessory extends Accessory {
 
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/fan-mode-switch-accessory.js
+++ b/src/accessories/fan-mode-switch-accessory.js
@@ -188,6 +188,7 @@ class FanModeSwitchAccessory extends Accessory {
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/index.js
+++ b/src/accessories/index.js
@@ -3,6 +3,7 @@
 const ThermostatAccessory = require('./thermostat-accessory');
 const FanAccessory = require('./fan-accessory');
 const VerticalAirflowDirectionAccessory = require('./vertical-airflow-direction-accessory');
+const AutoFanSpeedSwitchAccessory = require('./auto-fan-speed-switch-accessory');
 const DryModeSwitchAccessory = require('./dry-mode-switch-accessory');
 const EconomySwitchAccessory = require('./economy-switch-accessory');
 const EnergySavingFanSwitchAccessory = require('./energy-saving-fan-switch-accessory');
@@ -14,6 +15,7 @@ module.exports = {
     ThermostatAccessory,
     FanAccessory,
     VerticalAirflowDirectionAccessory,
+    AutoFanSpeedSwitchAccessory,
     DryModeSwitchAccessory,
     EconomySwitchAccessory,
     EnergySavingFanSwitchAccessory,

--- a/src/accessories/minimum-heat-mode-switch-accessory.js
+++ b/src/accessories/minimum-heat-mode-switch-accessory.js
@@ -264,6 +264,7 @@ class MinimumHeatModeSwitchAccessory extends Accessory {
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/powerful-switch-accessory.js
+++ b/src/accessories/powerful-switch-accessory.js
@@ -173,6 +173,7 @@ class PowerfulSwitchAccessory extends Accessory {
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -422,6 +422,7 @@ class ThermostatAccessory extends Accessory {
 
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshVerticalAirflowDirectionAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/accessories/vertical-airflow-direction-accessory.js
+++ b/src/accessories/vertical-airflow-direction-accessory.js
@@ -358,6 +358,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
 
         accessoryManager.refreshThermostatAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshFanAccessoryCharacteristics(this.deviceId);
+        accessoryManager.refreshAutoFanSpeedSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshDryModeSwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEconomySwitchAccessoryCharacteristics(this.deviceId);
         accessoryManager.refreshEnergySavingFanSwitchAccessoryCharacteristics(this.deviceId);

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ module.exports.ACCESSORY_SUFFIX_FAN = 'fan';
 // VerticalAirflowDirectionAccessory
 module.exports.ACCESSORY_SUFFIX_VERTICAL_SLATS = 'vertical-slats';
 module.exports.ACCESSORY_SUFFIX_VERTICAL_AIRFLOW_DIRECTION = 'vertical-airflow-direction';
+module.exports.ACCESSORY_SUFFIX_AUTO_FAN_SPEED_SWITCH = 'auto-fan-speed-switch';
 module.exports.ACCESSORY_SUFFIX_DRY_MODE_SWITCH = 'dry-mode-switch';
 module.exports.ACCESSORY_SUFFIX_ECONOMY_SWITCH = 'economy-switch';
 module.exports.ACCESSORY_SUFFIX_ENERGY_SAVING_FAN_SWITCH = 'energy-saving-fan-switch';

--- a/src/platform-accessory-manager.js
+++ b/src/platform-accessory-manager.js
@@ -79,6 +79,28 @@ class PlatformAccessoryManager {
         }
     }
 
+    registerAutoFanSpeedSwitchAccessory(deviceId, deviceName, model) {
+        const suffix = constants.ACCESSORY_SUFFIX_AUTO_FAN_SPEED_SWITCH;
+        const existingAccessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (existingAccessory) {
+            this._updateExistingAccessory(existingAccessory, deviceId, model);
+
+            new accessories.AutoFanSpeedSwitchAccessory(this.platform, existingAccessory);
+        } else {
+            const newAccessory = this._instantiateNewAccessory(
+                deviceId,
+                deviceName,
+                model,
+                suffix
+            );
+
+            new accessories.AutoFanSpeedSwitchAccessory(this.platform, newAccessory);
+
+            this._registerNewAccessory(newAccessory, deviceId, model);
+        }
+    }
+
     registerDryModeSwitchAccessory(deviceId, deviceName, model) {
         const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
         const existingAccessory = this._getExistingAccessory(deviceId, suffix);
@@ -237,6 +259,12 @@ class PlatformAccessoryManager {
         this._unregisterAccessory(deviceId, deviceName, suffix);
     }
 
+    unregisterAutoFanSpeedSwitchAccessory(deviceId, deviceName) {
+        const suffix = constants.ACCESSORY_SUFFIX_AUTO_FAN_SPEED_SWITCH;
+
+        this._unregisterAccessory(deviceId, deviceName, suffix);
+    }
+
     unregisterDryModeSwitchAccessory(deviceId, deviceName) {
         const suffix = constants.ACCESSORY_SUFFIX_DRY_MODE_SWITCH;
 
@@ -277,6 +305,7 @@ class PlatformAccessoryManager {
         this.refreshThermostatAccessoryCharacteristics(deviceId);
         this.refreshFanAccessoryCharacteristics(deviceId);
         this.refreshVerticalAirflowDirectionAccessoryCharacteristics(deviceId);
+        this.refreshAutoFanSpeedSwitchAccessoryCharacteristics(deviceId);
         this.refreshDryModeSwitchAccessoryCharacteristics(deviceId);
         this.refreshEconomySwitchAccessoryCharacteristics(deviceId);
         this.refreshEnergySavingFanSwitchAccessoryCharacteristics(deviceId);
@@ -339,6 +368,22 @@ class PlatformAccessoryManager {
                 this.Characteristic.Active,
                 this.Characteristic.CurrentFanState,
                 this.Characteristic.RotationSpeed
+            ]
+        );
+    }
+
+    refreshAutoFanSpeedSwitchAccessoryCharacteristics(deviceId) {
+        const suffix = constants.ACCESSORY_SUFFIX_AUTO_FAN_SPEED_SWITCH;
+        const accessory = this._getExistingAccessory(deviceId, suffix);
+
+        if (accessory === null) {
+            return false;
+        }
+
+        return this._refreshAccessoryCharacteristics(
+            accessory,
+            [
+                this.Characteristic.On
             ]
         );
     }

--- a/src/platform.js
+++ b/src/platform.js
@@ -190,6 +190,20 @@ class Platform {
             );
         }
 
+        // "Auto Fan Speed" switch
+        if (this.config.enableAutoFanSpeedSwitch) {
+            this.accessoryManager.registerAutoFanSpeedSwitchAccessory(
+                deviceId,
+                deviceName,
+                model
+            );
+        } else {
+            this.accessoryManager.unregisterAutoFanSpeedSwitchAccessory(
+                deviceId,
+                deviceName
+            );
+        }
+
         // "Dry Mode" switch
         if (this.config.enableDryModeSwitch) {
             this.accessoryManager.registerDryModeSwitchAccessory(

--- a/test/accessories/test-auto-fan-speed-switch-accessory.js
+++ b/test/accessories/test-auto-fan-speed-switch-accessory.js
@@ -1,0 +1,540 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mock, test } = require('node:test');
+const AutoFanSpeedSwitchAccessory = require('../../src/accessories/auto-fan-speed-switch-accessory');
+const MockHomebridge = require('../../src/test/mock-homebridge');
+const airstage = require('../../src/airstage');
+
+const mockHomebridge = new MockHomebridge();
+const platformAccessory = new mockHomebridge.platform.api.platformAccessory(
+    'test-name',
+    'test-uuid'
+);
+
+test('AutoFanSpeedSwitchAccessory#constructor registers accessory', (context) => {
+    context.mock.method(
+        platformAccessory,
+        'getService'
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    assert.strictEqual(platformAccessory.getService.mock.calls.length, 2);
+    assert.strictEqual(
+        platformAccessory.getService.mock.calls[0].arguments[0],
+        mockHomebridge.platform.Service.AccessoryInformation
+    );
+    assert.strictEqual(
+        platformAccessory.getService.mock.calls[1].arguments[0],
+        mockHomebridge.platform.Service.Switch
+    );
+
+    mockHomebridge.resetMocks();
+});
+
+test('AutoFanSpeedSwitchAccessory#constructor configures event listeners', (context) => {
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    assert.strictEqual(mockHomebridge.service.getCharacteristic.mock.calls.length, 2);
+    assert.strictEqual(
+        mockHomebridge.service.getCharacteristic.mock.calls[0].arguments[0],
+        mockHomebridge.platform.Characteristic.On
+    );
+    assert.strictEqual(
+        mockHomebridge.service.getCharacteristic.mock.calls[1].arguments[0],
+        mockHomebridge.platform.Characteristic.Name
+    );
+    assert.strictEqual(mockHomebridge.characteristic.on.mock.calls.length, 3);
+    assert.strictEqual(
+        mockHomebridge.characteristic.on.mock.calls[0].arguments[0],
+        'get'
+    );
+    assert.strictEqual(
+        mockHomebridge.characteristic.on.mock.calls[0].arguments[1].name,
+        autoFanSpeedSwitchAccessory.getOn.bind(autoFanSpeedSwitchAccessory).name
+    );
+    assert.strictEqual(
+        mockHomebridge.characteristic.on.mock.calls[1].arguments[0],
+        'set'
+    );
+    assert.strictEqual(
+        mockHomebridge.characteristic.on.mock.calls[1].arguments[1].name,
+        autoFanSpeedSwitchAccessory.setOn.bind(autoFanSpeedSwitchAccessory).name
+    );
+    assert.strictEqual(
+        mockHomebridge.characteristic.on.mock.calls[2].arguments[0],
+        'get'
+    );
+    assert.strictEqual(
+        mockHomebridge.characteristic.on.mock.calls[2].arguments[1].name,
+        autoFanSpeedSwitchAccessory.getName.bind(autoFanSpeedSwitchAccessory).name
+    );
+
+    mockHomebridge.resetMocks();
+});
+
+test('AutoFanSpeedSwitchAccessory#getOn when getPowerState returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback('getPowerState error', null);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.getOn(function(error, value) {
+        assert.strictEqual(error, 'getPowerState error');
+        assert.strictEqual(value, null);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#getOn when getPowerState returns OFF', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_OFF);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.getOn(function(error, value) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(value, false);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#getOn when getPowerState returns ON and getFanSpeed returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_ON);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback('getFanSpeed error', null);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.getOn(function(error, value) {
+        assert.strictEqual(error, 'getFanSpeed error');
+        assert.strictEqual(value, null);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#getOn when getPowerState returns ON and getFanSpeed returns FAN_SPEED_LOW', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_ON);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.FAN_SPEED_LOW);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.getOn(function(error, value) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(value, false);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#getOn when getPowerState returns ON and getFanSpeed returns FAN_SPEED_AUTO', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_ON);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.FAN_SPEED_AUTO);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.getOn(function(error, value) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(value, true);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns error', (context, done) => {
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback('getPowerState error', null);
+        }
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, 'getPowerState error');
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns ON and getFanSpeed returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_ON);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback('getFanSpeed error', null);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, 'getFanSpeed error');
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns ON and setFanSpeed returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_ON);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.FAN_SPEED_LOW);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setFanSpeed',
+        (deviceId, fanSpeed, callback) => {
+            callback('setFanSpeed error');
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, 'setFanSpeed error');
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns ON and getFanSpeed returns FAN_SPEED_LOW', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_ON);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.FAN_SPEED_LOW);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setFanSpeed',
+        (deviceId, fanSpeed, callback) => {
+            assert.strictEqual(fanSpeed, airstage.constants.FAN_SPEED_AUTO);
+
+            callback(null);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(autoFanSpeedSwitchAccessory.lastKnownFanSpeed, airstage.constants.FAN_SPEED_LOW);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns OFF and setPowerState returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_OFF);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setPowerState',
+        (deviceId, powerState, callback) => {
+            callback('setPowerState error');
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, 'setPowerState error');
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns OFF and getFanSpeed returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_OFF);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setPowerState',
+        (deviceId, powerState, callback) => {
+            callback(null);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback('getFanSpeed error');
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, 'getFanSpeed error');
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns OFF and setFanSpeed returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_OFF);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setPowerState',
+        (deviceId, powerState, callback) => {
+            callback(null);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.FAN_SPEED_LOW);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setFanSpeed',
+        (deviceId, fanSpeed, callback) => {
+            callback('setFanSpeed error');
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, 'setFanSpeed error');
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#setOn when getPowerState returns OFF and getFanSpeed returns FAN_SPEED_LOW', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.TOGGLE_OFF);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setPowerState',
+        (deviceId, powerState, callback) => {
+            assert.strictEqual(powerState, airstage.constants.TOGGLE_ON);
+
+            callback(null);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getFanSpeed',
+        (deviceId, callback) => {
+            callback(null, airstage.constants.FAN_SPEED_LOW);
+        }
+    );
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'setFanSpeed',
+        (deviceId, fanSpeed, callback) => {
+            assert.strictEqual(fanSpeed, airstage.constants.FAN_SPEED_AUTO);
+
+            callback(null);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.setOn(true, function(error) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(autoFanSpeedSwitchAccessory.lastKnownFanSpeed, airstage.constants.FAN_SPEED_LOW);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#getName when getName returns error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getName',
+        (deviceId, callback) => {
+            callback('getName error', null);
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.getName(function(error, name) {
+        assert.strictEqual(error, 'getName error');
+        assert.strictEqual(name, null);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('AutoFanSpeedSwitchAccessory#getName returns name with expected suffix', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getName',
+        (deviceId, callback) => {
+            callback(null, 'Test Device');
+        }
+    );
+    const autoFanSpeedSwitchAccessory = new AutoFanSpeedSwitchAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    autoFanSpeedSwitchAccessory.getName(function(error, name) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(name, 'Test Device Auto Fan Speed Switch');
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});

--- a/test/test-platform-accessory-manager.js
+++ b/test/test-platform-accessory-manager.js
@@ -149,6 +149,50 @@ test('PlatformAccessoryManager#registerVerticalAirflowDirectionAccessory registe
     mockHomebridge.resetMocks();
 });
 
+test('PlatformAccessoryManager#registerAutoFanSpeedSwitchAccessory registers existing accessory', (context) => {
+    const existingUuid = hap.uuid.generate(
+        deviceId + '-auto-fan-speed-switch'
+    );
+    const existingPlatformAccessory = new mockHomebridge.platform.api.platformAccessory(
+        'Test Device Auto Fan Speed Switch',
+        existingUuid
+    );
+    mockHomebridge.platform.accessories = [existingPlatformAccessory];
+
+    platformAccessoryManager.registerAutoFanSpeedSwitchAccessory(deviceId, deviceName, deviceModel);
+
+    const mockedMethod = mockHomebridge.platform.api.updatePlatformAccessories.mock;
+    assert.strictEqual(mockedMethod.calls.length, 1);
+    const mockPlatformAccessory = mockedMethod.calls[0].arguments[0][0];
+    assert.strictEqual(mockPlatformAccessory, existingPlatformAccessory);
+    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Auto Fan Speed Switch');
+    assert.strictEqual(mockPlatformAccessory.context.airstageClient, mockHomebridge.platform.airstageClient);
+    assert.strictEqual(mockPlatformAccessory.context.deviceId, deviceId);
+    assert.strictEqual(mockPlatformAccessory.context.model, deviceModel);
+    assert.strictEqual(mockHomebridge.platform.accessories.length, 1);
+    assert.strictEqual(mockHomebridge.platform.accessories[0], mockPlatformAccessory);
+
+    mockHomebridge.resetMocks();
+});
+
+test('PlatformAccessoryManager#registerAutoFanSpeedSwitchAccessory registers new accessory', (context) => {
+    platformAccessoryManager.registerAutoFanSpeedSwitchAccessory(deviceId, deviceName, deviceModel);
+
+    const mockedMethod = mockHomebridge.platform.api.registerPlatformAccessories.mock;
+    assert.strictEqual(mockedMethod.calls.length, 1);
+    assert.strictEqual(mockedMethod.calls[0].arguments[0], settings.PLUGIN_NAME);
+    assert.strictEqual(mockedMethod.calls[0].arguments[1], settings.PLATFORM_NAME);
+    const mockPlatformAccessory = mockedMethod.calls[0].arguments[2][0];
+    assert.strictEqual(mockPlatformAccessory.name, 'Test Device Auto Fan Speed Switch');
+    assert.strictEqual(mockPlatformAccessory.context.airstageClient, mockHomebridge.platform.airstageClient);
+    assert.strictEqual(mockPlatformAccessory.context.deviceId, deviceId);
+    assert.strictEqual(mockPlatformAccessory.context.model, deviceModel);
+    assert.strictEqual(mockHomebridge.platform.accessories.length, 1);
+    assert.strictEqual(mockHomebridge.platform.accessories[0], mockPlatformAccessory);
+
+    mockHomebridge.resetMocks();
+});
+
 test('PlatformAccessoryManager#registerDryModeSwitchAccessory registers existing accessory', (context) => {
     const existingUuid = hap.uuid.generate(
         deviceId + '-dry-mode-switch'

--- a/test/test-platform.js
+++ b/test/test-platform.js
@@ -538,6 +538,128 @@ test('Platform#discoverDevices does not register accessory when enableVerticalAi
     });
 });
 
+test('Platform#discoverDevices registers accessory when enableAutoFanSpeedSwitch is true', (context, done) => {
+    const platformConfig = {
+        'platform': 'fujitsu-airstage',
+        'region': 'us',
+        'country': 'United States',
+        'language': 'en',
+        'email': 'test@example.com',
+        'password': 'test1234',
+        'enableAutoFanSpeedSwitch': true
+    };
+    const platform = new Platform(
+        mockHomebridge.platform.log,
+        platformConfig,
+        mockHomebridge.platform.api,
+        false
+    );
+    context.mock.method(
+        platform.airstageClient,
+        'refreshTokenOrAuthenticate',
+        (callback) => {
+            callback(null);
+        }
+    );
+    context.mock.method(
+        platform.airstageClient,
+        'getUserMetadata',
+        (callback) => {
+            callback(null);
+        }
+    );
+
+    context.mock.method(
+        platform.airstageClient,
+        'getDevices',
+        (limit, callback) => {
+            callback(null, {
+                'metadata': {
+                    'testDevice': {
+                        'deviceName': 'Test Device'
+                    }
+                },
+                'parameters': {
+                    'testDevice': {
+                        'iu_model': 'Fujitsu Mini Split'
+                    }
+                }
+            });
+        }
+    );
+
+    platform.discoverDevices(function(error) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(platform.accessories.length, 1);
+        const accessory = platform.accessories[0];
+        assert.strictEqual(accessory.name, 'Test Device Auto Fan Speed Switch');
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
+test('Platform#discoverDevices does not register accessory when enableAutoFanSpeedSwitch is false', (context, done) => {
+    const platformConfig = {
+        'platform': 'fujitsu-airstage',
+        'region': 'us',
+        'country': 'United States',
+        'language': 'en',
+        'email': 'test@example.com',
+        'password': 'test1234',
+        'enableAutoFanSpeedSwitch': false
+    };
+    const platform = new Platform(
+        mockHomebridge.platform.log,
+        platformConfig,
+        mockHomebridge.platform.api,
+        false
+    );
+    context.mock.method(
+        platform.airstageClient,
+        'refreshTokenOrAuthenticate',
+        (callback) => {
+            callback(null);
+        }
+    );
+    context.mock.method(
+        platform.airstageClient,
+        'getUserMetadata',
+        (callback) => {
+            callback(null);
+        }
+    );
+
+    context.mock.method(
+        platform.airstageClient,
+        'getDevices',
+        (limit, callback) => {
+            callback(null, {
+                'metadata': {
+                    'testDevice': {
+                        'deviceName': 'Test Device'
+                    }
+                },
+                'parameters': {
+                    'testDevice': {
+                        'iu_model': 'Fujitsu Mini Split'
+                    }
+                }
+            });
+        }
+    );
+
+    platform.discoverDevices(function(error) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(platform.accessories.length, 0);
+
+        mockHomebridge.resetMocks();
+
+        done();
+    });
+});
+
 test('Platform#discoverDevices registers accessory when enableDryModeSwitch is true', (context, done) => {
     const platformConfig = {
         'platform': 'fujitsu-airstage',


### PR DESCRIPTION
In the Apple Home UI, setting a fan's speed to "auto" requires you to open the settings of the device in order to toggle between "auto" and "manual". Having a standalone switch accessory to do this is useful, so that you can more quickly and easily toggle it on and off.