### PR TITLE
Add Airstage API polling interval to the config, default it to 30 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ installed and configured this plugin:
             "language": "en",
             "email": "test@example.com",
             "password": "test1234",
+            "apiPollingInterval": 30,
             "enableThermostat": true,
             "enableFan": true,
             "enableVerticalAirflowDirection": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -56,6 +56,12 @@
                 "default": "",
                 "description": "The password for your Airstage account."
             },
+            "apiPollingInterval": {
+                "title": "Airstage API Polling Interval",
+                "type": "integer",
+                "default": 30,
+                "description": "The polling interval for getting updates from the Airstage API, in minutes. WARNING: setting this too low may result in getting your IP banned from accessing the Airstage API! Set to '0' to disable polling completely."
+            },
             "enableThermostat": {
                 "title": "Enable thermostat control",
                 "type": "boolean",

--- a/src/platform.js
+++ b/src/platform.js
@@ -46,10 +46,14 @@ class Platform {
         );
 
         if (withSetInterval) {
-            setInterval(
-                this._refreshAirstageClientCache.bind(this),
-                (5 * 60 * 1000) // 5 minutes
-            );
+            const apiPollingInterval = ((this.config.apiPollingInterval * 1000) * 60);
+
+            if (apiPollingInterval > 0) {
+                setInterval(
+                    this._refreshAirstageClientCache.bind(this),
+                    apiPollingInterval
+                );
+            }
 
             setInterval(
                 this._refreshAirstageClientTokenOrAuthenticate.bind(this),


### PR DESCRIPTION
We think that excessive polling from the plugin may have resulted in some people getting their IP banned from the Airstage API (see #33). To help prevent this, make polling the Airstage API user configurable, and have it set to 30 minutes by default. It can also be disabled entirely by setting it to '0'.