### PR TITLE
feat: Centralized error handling with HomeKit StatusFault reporting

### DIFF
--- a/src/accessories/accessory.js
+++ b/src/accessories/accessory.js
@@ -57,14 +57,16 @@ class Accessory {
     _handleError(methodName, error, callback, includeNull = true) {
         this._logMethodCallResult(methodName, error);
 
-        // Check if error indicates device is unreachable
-        const errorMessage = error?.message || '';
-        const isUnreachableError = errorMessage.includes('unreachable') ||
-                                   errorMessage.includes('timeout') ||
-                                   errorMessage.includes('ECONNREFUSED') ||
-                                   errorMessage.includes('EHOSTUNREACH') ||
-                                   errorMessage.includes('ETIMEDOUT') ||
-                                   errorMessage.includes('ENETUNREACH');
+        // Prefer the Node errno code (unambiguous). Fall back to a
+        // word-boundary message match so substrings like "timeout" inside
+        // unrelated API error text don't trigger false positives.
+        const unreachableCodes = new Set([
+            'ECONNREFUSED', 'EHOSTUNREACH', 'ETIMEDOUT', 'ENETUNREACH', 'ENOTFOUND', 'ECONNRESET'
+        ]);
+        const errorCode = (error && typeof error === 'object' && error.code) || '';
+        const errorMessage = ((error && error.message) || '').toLowerCase();
+        const isUnreachableError = unreachableCodes.has(errorCode) ||
+                                   /\b(unreachable|timed[\s-]?out|timeout)\b/.test(errorMessage);
 
         if (isUnreachableError) {
             // Update StatusFault to indicate device problem
@@ -77,7 +79,7 @@ class Accessory {
             }
 
             this.platform.log.warn(
-                `[${this.constructor.name}] Device ${this.deviceId} appears unreachable: ${errorMessage}`
+                `[${this.constructor.name}] Device ${this.deviceId} appears unreachable: ${error?.message || errorCode || error}`
             );
         } else {
             // For non-unreachable errors, ensure StatusFault is cleared

--- a/src/accessories/accessory.js
+++ b/src/accessories/accessory.js
@@ -18,7 +18,8 @@ class Accessory {
         this.accessory.getService(this.Service.AccessoryInformation)
             .setCharacteristic(this.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
             .setCharacteristic(this.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.Characteristic.SerialNumber, this.accessory.context.deviceId);
+            .setCharacteristic(this.Characteristic.SerialNumber, this.accessory.context.deviceId)
+            .setCharacteristic(this.Characteristic.StatusFault, this.Characteristic.StatusFault.NO_FAULT);
     }
 
     _refreshDynamicServiceCharacteristics() {
@@ -51,6 +52,49 @@ class Accessory {
             }
 
             this.platform.log.debug(logMessage);
+        }
+    }
+    _handleError(methodName, error, callback, includeNull = true) {
+        this._logMethodCallResult(methodName, error);
+
+        // Check if error indicates device is unreachable
+        const errorMessage = error?.message || '';
+        const isUnreachableError = errorMessage.includes('unreachable') ||
+                                   errorMessage.includes('timeout') ||
+                                   errorMessage.includes('ECONNREFUSED') ||
+                                   errorMessage.includes('EHOSTUNREACH') ||
+                                   errorMessage.includes('ETIMEDOUT') ||
+                                   errorMessage.includes('ENETUNREACH');
+
+        if (isUnreachableError) {
+            // Update StatusFault to indicate device problem
+            const infoService = this.accessory.getService(this.Service.AccessoryInformation);
+            if (infoService) {
+                infoService.setCharacteristic(
+                    this.Characteristic.StatusFault,
+                    this.Characteristic.StatusFault.GENERAL_FAULT
+                );
+            }
+
+            this.platform.log.warn(
+                `[${this.constructor.name}] Device ${this.deviceId} appears unreachable: ${errorMessage}`
+            );
+        } else {
+            // For non-unreachable errors, ensure StatusFault is cleared
+            const infoService = this.accessory.getService(this.Service.AccessoryInformation);
+            if (infoService) {
+                infoService.setCharacteristic(
+                    this.Characteristic.StatusFault,
+                    this.Characteristic.StatusFault.NO_FAULT
+                );
+            }
+        }
+
+        // Support both callback(error, null) and callback(error) patterns
+        if (includeNull) {
+            callback(error, null);
+        } else {
+            callback(error);
         }
     }
 }

--- a/src/accessories/auto-fan-speed-switch-accessory.js
+++ b/src/accessories/auto-fan-speed-switch-accessory.js
@@ -34,9 +34,7 @@ class FanModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -53,9 +51,7 @@ class FanModeSwitchAccessory extends Accessory {
                         let value = null;
 
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error, null);
+                            return this._handleError(methodName, error, callback);
                         }
 
                         value = (fanSpeed === airstage.constants.FAN_SPEED_AUTO);
@@ -92,9 +88,7 @@ class FanModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -103,9 +97,7 @@ class FanModeSwitchAccessory extends Accessory {
                         airstage.constants.TOGGLE_ON,
                         (function(error) {
                             if (error) {
-                                this._logMethodCallResult(methodName, error);
-
-                                return callback(error);
+                                return this._handleError(methodName, error, callback, false);
                             }
 
                             this._setFanSpeed(
@@ -135,9 +127,7 @@ class FanModeSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Auto Fan Speed Switch';
@@ -154,9 +144,7 @@ class FanModeSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, currentFanSpeed) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 this.lastKnownFanSpeed = currentFanSpeed;
@@ -166,9 +154,7 @@ class FanModeSwitchAccessory extends Accessory {
                     fanSpeed,
                     (function(error) {
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error);
+                            return this._handleError(methodName, error, callback, false);
                         }
 
                         this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/dry-mode-switch-accessory.js
+++ b/src/accessories/dry-mode-switch-accessory.js
@@ -34,9 +34,7 @@ class DryModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -92,9 +90,7 @@ class DryModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -135,9 +131,7 @@ class DryModeSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Dry Mode Switch';
@@ -166,9 +160,7 @@ class DryModeSwitchAccessory extends Accessory {
                     operationMode,
                     (function(error) {
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error);
+                            return this._handleError(methodName, error, callback, false);
                         }
 
                         this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/economy-switch-accessory.js
+++ b/src/accessories/economy-switch-accessory.js
@@ -32,9 +32,7 @@ class EconomySwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -51,9 +49,7 @@ class EconomySwitchAccessory extends Accessory {
                         let value = null;
 
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error, null);
+                            return this._handleError(methodName, error, callback);
                         }
 
                         if (economyState === airstage.constants.TOGGLE_ON) {
@@ -90,9 +86,7 @@ class EconomySwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -101,9 +95,7 @@ class EconomySwitchAccessory extends Accessory {
                         airstage.constants.TOGGLE_ON,
                         (function(error) {
                             if (error) {
-                                this._logMethodCallResult(methodName, error);
-
-                                return callback(error);
+                                return this._handleError(methodName, error, callback, false);
                             }
 
                             this._setEconomyState(
@@ -133,9 +125,7 @@ class EconomySwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Economy Switch';
@@ -153,9 +143,7 @@ class EconomySwitchAccessory extends Accessory {
             economyState,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/energy-saving-fan-switch-accessory.js
+++ b/src/accessories/energy-saving-fan-switch-accessory.js
@@ -32,9 +32,7 @@ class EnergySavingFanSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -90,9 +88,7 @@ class EnergySavingFanSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -133,9 +129,7 @@ class EnergySavingFanSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Energy Saving Fan Switch';
@@ -153,9 +147,7 @@ class EnergySavingFanSwitchAccessory extends Accessory {
             energySavingFanState,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/fan-accessory.js
+++ b/src/accessories/fan-accessory.js
@@ -53,9 +53,7 @@ class FanAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_ON) {
@@ -89,9 +87,7 @@ class FanAccessory extends Accessory {
             powerState,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);
@@ -115,9 +111,7 @@ class FanAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_ON) {
@@ -144,9 +138,7 @@ class FanAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (fanSpeed === airstage.constants.FAN_SPEED_AUTO) {
@@ -173,9 +165,7 @@ class FanAccessory extends Accessory {
                 airstage.constants.FAN_SPEED_AUTO,
                 (function(error) {
                     if (error) {
-                        this._logMethodCallResult(methodName, error);
-
-                        return callback(error);
+                        return this._handleError(methodName, error, callback, false);
                     }
 
                     this._logMethodCallResult(methodName, null, null);
@@ -205,9 +195,7 @@ class FanAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Fan';
@@ -230,9 +218,7 @@ class FanAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (fanSpeed === airstage.constants.FAN_SPEED_AUTO) {
@@ -301,9 +287,7 @@ class FanAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (swingState === airstage.constants.TOGGLE_ON) {
@@ -337,9 +321,7 @@ class FanAccessory extends Accessory {
             swingState,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/fan-mode-switch-accessory.js
+++ b/src/accessories/fan-mode-switch-accessory.js
@@ -34,9 +34,7 @@ class FanModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -92,9 +90,7 @@ class FanModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -135,9 +131,7 @@ class FanModeSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Fan Mode Switch';
@@ -154,9 +148,7 @@ class FanModeSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, currentOperationMode) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 this.lastKnownOperationMode = currentOperationMode;
@@ -166,9 +158,7 @@ class FanModeSwitchAccessory extends Accessory {
                     operationMode,
                     (function(error) {
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error);
+                            return this._handleError(methodName, error, callback, false);
                         }
 
                         this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/minimum-heat-mode-switch-accessory.js
+++ b/src/accessories/minimum-heat-mode-switch-accessory.js
@@ -35,9 +35,7 @@ class MinimumHeatModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -93,9 +91,7 @@ class MinimumHeatModeSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -136,9 +132,7 @@ class MinimumHeatModeSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Minimum Heat Mode Switch';
@@ -175,9 +169,7 @@ class MinimumHeatModeSwitchAccessory extends Accessory {
                     airstage.constants.TEMPERATURE_SCALE_CELSIUS,
                     (function(error, targetTemperature) {
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error);
+                            return this._handleError(methodName, error, callback, false);
                         }
 
                         this.lastKnownTargetTemperature = targetTemperature;

--- a/src/accessories/powerful-switch-accessory.js
+++ b/src/accessories/powerful-switch-accessory.js
@@ -32,9 +32,7 @@ class PowerfulSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -90,9 +88,7 @@ class PowerfulSwitchAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -133,9 +129,7 @@ class PowerfulSwitchAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Powerful Switch';
@@ -153,9 +147,7 @@ class PowerfulSwitchAccessory extends Accessory {
             powerfulState,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/thermostat-accessory.js
+++ b/src/accessories/thermostat-accessory.js
@@ -48,9 +48,7 @@ class ThermostatAccessory extends Accessory {
             this.deviceId,
             (function(error, powerState) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -125,9 +123,7 @@ class ThermostatAccessory extends Accessory {
             this.deviceId,
             (function(error, powerState) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -188,9 +184,7 @@ class ThermostatAccessory extends Accessory {
             this.deviceId,
             (function(error, powerState) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (value === this.Characteristic.TargetHeatingCoolingState.OFF) {
@@ -262,9 +256,7 @@ class ThermostatAccessory extends Accessory {
             airstage.constants.TEMPERATURE_SCALE_CELSIUS,
             (function (error, indoorTemperature) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 this._logMethodCallResult(methodName, null, indoorTemperature);
@@ -284,9 +276,7 @@ class ThermostatAccessory extends Accessory {
             airstage.constants.TEMPERATURE_SCALE_CELSIUS,
             (function (error, targetTemperature) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 this._logMethodCallResult(methodName, null, targetTemperature);
@@ -307,9 +297,7 @@ class ThermostatAccessory extends Accessory {
             airstage.constants.TEMPERATURE_SCALE_CELSIUS,
             (function (error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);
@@ -331,9 +319,7 @@ class ThermostatAccessory extends Accessory {
                 let temperatureDisplayUnits = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (temperatureScale === airstage.constants.TEMPERATURE_SCALE_CELSIUS) {
@@ -366,9 +352,7 @@ class ThermostatAccessory extends Accessory {
             temperatureScale,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);
@@ -387,9 +371,7 @@ class ThermostatAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Thermostat';
@@ -407,9 +389,7 @@ class ThermostatAccessory extends Accessory {
             operationMode,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);

--- a/src/accessories/vertical-airflow-direction-accessory.js
+++ b/src/accessories/vertical-airflow-direction-accessory.js
@@ -46,9 +46,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -65,9 +63,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
                         let value = null;
 
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error, null);
+                            return this._handleError(methodName, error, callback);
                         }
 
                         if (swingState === airstage.constants.TOGGLE_ON) {
@@ -104,9 +100,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -115,9 +109,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
                         airstage.constants.TOGGLE_ON,
                         (function(error) {
                             if (error) {
-                                this._logMethodCallResult(methodName, error);
-
-                                return callback(error);
+                                return this._handleError(methodName, error, callback, false);
                             }
 
                             this._setAirflowVerticalSwingState(
@@ -149,9 +141,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
                 let value = null;
 
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -166,9 +156,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
                     this.deviceId,
                     (function(error, swingState) {
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error, null);
+                            return this._handleError(methodName, error, callback);
                         }
 
                         if (swingState === airstage.constants.TOGGLE_ON) {
@@ -195,9 +183,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
             this.deviceId,
             (function(error, name) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 const value = name + ' Vertical Airflow Direction';
@@ -220,9 +206,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
             this.deviceId,
             (function(error, powerState) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error, null);
+                    return this._handleError(methodName, error, callback);
                 }
 
                 if (powerState === airstage.constants.TOGGLE_OFF) {
@@ -237,9 +221,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
                     this.deviceId,
                     (function(error, airflowVerticalDirection) {
                         if (error) {
-                            this._logMethodCallResult(methodName, error);
-
-                            return callback(error, null);
+                            return this._handleError(methodName, error, callback);
                         }
 
                         if (airflowVerticalDirection === 1) {
@@ -310,9 +292,7 @@ class VerticalAirflowDirectionAccessory extends Accessory {
             swingState,
             (function(error) {
                 if (error) {
-                    this._logMethodCallResult(methodName, error);
-
-                    return callback(error);
+                    return this._handleError(methodName, error, callback, false);
                 }
 
                 this._logMethodCallResult(methodName, null, null);

--- a/src/test/mock-homebridge.js
+++ b/src/test/mock-homebridge.js
@@ -83,7 +83,8 @@ const mockPlatform = {
     'log': {
         'debug': mock.fn(() => {}),
         'error': mock.fn(() => {}),
-        'info': mock.fn(() => {})
+        'info': mock.fn(() => {}),
+        'warn': mock.fn(() => {})
     }
 };
 
@@ -106,6 +107,7 @@ class MockHomebridge {
         mockPlatform.log.debug.mock.resetCalls();
         mockPlatform.log.error.mock.resetCalls();
         mockPlatform.log.info.mock.resetCalls();
+        mockPlatform.log.warn.mock.resetCalls();
         mockPlatform.accessories = [];
     }
 }

--- a/test/accessories/test-fan-accessory.js
+++ b/test/accessories/test-fan-accessory.js
@@ -174,6 +174,155 @@ test('FanAccessory#getActive when getPowerState returns error', (context, done) 
     });
 });
 
+test('Accessory#_handleError sets StatusFault.NO_FAULT on construction', (context) => {
+    new FanAccessory(mockHomebridge.platform, platformAccessory);
+
+    const noFaultCalls = mockHomebridge.service.setCharacteristic.mock.calls.filter(
+        (call) => call.arguments[0] === mockHomebridge.platform.Characteristic.StatusFault &&
+                  call.arguments[1] === mockHomebridge.platform.Characteristic.StatusFault.NO_FAULT
+    );
+    assert.ok(noFaultCalls.length >= 1, 'StatusFault.NO_FAULT should be set at least once on construction');
+
+    mockHomebridge.resetMocks();
+});
+
+test('Accessory#_handleError sets GENERAL_FAULT on errno-coded unreachable error', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            const err = new Error('connect ECONNREFUSED 192.168.1.50:80');
+            err.code = 'ECONNREFUSED';
+            callback(err, null);
+        }
+    );
+    const fanAccessory = new FanAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    fanAccessory.getActive(function(error, value) {
+        const faultCalls = mockHomebridge.service.setCharacteristic.mock.calls.filter(
+            (call) => call.arguments[0] === mockHomebridge.platform.Characteristic.StatusFault &&
+                      call.arguments[1] === mockHomebridge.platform.Characteristic.StatusFault.GENERAL_FAULT
+        );
+        assert.ok(faultCalls.length >= 1, 'GENERAL_FAULT should be set on ECONNREFUSED');
+        assert.ok(mockHomebridge.platform.log.warn.mock.calls.length >= 1, 'warn should be logged for unreachable');
+
+        mockHomebridge.resetMocks();
+        done();
+    });
+});
+
+test('Accessory#_handleError sets GENERAL_FAULT on EHOSTUNREACH errno', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            const err = new Error('host unreachable');
+            err.code = 'EHOSTUNREACH';
+            callback(err, null);
+        }
+    );
+    const fanAccessory = new FanAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    fanAccessory.getActive(function() {
+        const faultCalls = mockHomebridge.service.setCharacteristic.mock.calls.filter(
+            (call) => call.arguments[0] === mockHomebridge.platform.Characteristic.StatusFault &&
+                      call.arguments[1] === mockHomebridge.platform.Characteristic.StatusFault.GENERAL_FAULT
+        );
+        assert.ok(faultCalls.length >= 1, 'GENERAL_FAULT should be set on EHOSTUNREACH');
+
+        mockHomebridge.resetMocks();
+        done();
+    });
+});
+
+test('Accessory#_handleError keeps NO_FAULT for non-network errors', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            const err = new Error('Invalid access token');
+            callback(err, null);
+        }
+    );
+    const fanAccessory = new FanAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    fanAccessory.getActive(function() {
+        const faultCalls = mockHomebridge.service.setCharacteristic.mock.calls.filter(
+            (call) => call.arguments[0] === mockHomebridge.platform.Characteristic.StatusFault &&
+                      call.arguments[1] === mockHomebridge.platform.Characteristic.StatusFault.GENERAL_FAULT
+        );
+        assert.strictEqual(faultCalls.length, 0, 'GENERAL_FAULT must not be set for auth errors');
+        assert.strictEqual(mockHomebridge.platform.log.warn.mock.calls.length, 0, 'warn must not be logged for non-network errors');
+
+        mockHomebridge.resetMocks();
+        done();
+    });
+});
+
+test('Accessory#_handleError does not false-positive on "timeout" inside non-network message', (context, done) => {
+    // Regression guard: substring match on "timeout" used to produce false positives.
+    // A word-boundary regex still matches the bare word, but messages like
+    // "TimeoutPolicyValidator" (camelCased identifier) should NOT match.
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            const err = new Error('TimeoutPolicyValidator: invalid configuration value');
+            callback(err, null);
+        }
+    );
+    const fanAccessory = new FanAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    fanAccessory.getActive(function() {
+        const faultCalls = mockHomebridge.service.setCharacteristic.mock.calls.filter(
+            (call) => call.arguments[0] === mockHomebridge.platform.Characteristic.StatusFault &&
+                      call.arguments[1] === mockHomebridge.platform.Characteristic.StatusFault.GENERAL_FAULT
+        );
+        assert.strictEqual(faultCalls.length, 0, 'TimeoutPolicyValidator must not be classified as unreachable');
+
+        mockHomebridge.resetMocks();
+        done();
+    });
+});
+
+test('Accessory#_handleError matches "Connection Timeout" case-insensitively', (context, done) => {
+    context.mock.method(
+        platformAccessory.context.airstageClient,
+        'getPowerState',
+        (deviceId, callback) => {
+            const err = new Error('Connection Timeout while contacting device');
+            callback(err, null);
+        }
+    );
+    const fanAccessory = new FanAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    fanAccessory.getActive(function() {
+        const faultCalls = mockHomebridge.service.setCharacteristic.mock.calls.filter(
+            (call) => call.arguments[0] === mockHomebridge.platform.Characteristic.StatusFault &&
+                      call.arguments[1] === mockHomebridge.platform.Characteristic.StatusFault.GENERAL_FAULT
+        );
+        assert.ok(faultCalls.length >= 1, 'Mixed-case "Timeout" should be classified as unreachable');
+
+        mockHomebridge.resetMocks();
+        done();
+    });
+});
+
 test('FanAccessory#getActive when getPowerState returns ON', (context, done) => {
     context.mock.method(
         platformAccessory.context.airstageClient,


### PR DESCRIPTION
## Summary

- Adds a centralized `_handleError()` method to the base `Accessory` class that detects unreachable devices (timeout, connection refused, host unreachable) and sets the HomeKit `StatusFault` characteristic
- Updates all 10 accessory classes to use the centralized error handler instead of inline error logging and callbacks
- Initializes `StatusFault.NO_FAULT` on all accessories at construction time

## How It Works

When an API call fails, `_handleError()` checks the error message for network-level indicators:
- `unreachable`, `timeout`, `ECONNREFUSED`, `EHOSTUNREACH`, `ETIMEDOUT`, `ENETUNREACH`

If detected, it sets `StatusFault.GENERAL_FAULT` on the accessory's `AccessoryInformation` service, providing visual indication in the Home app. For non-network errors, it ensures the fault is cleared.

This works with both cloud and local connection modes.

## Context

This is **PR 1 of 3** from the original PR #34, split as requested. The three PRs are:
1. **This PR** - Error handling & StatusFault reporting (independent)
2. Local LAN connection mode (depends on this PR)
3. Developer experience improvements (independent)

## Test Plan

- [x] All 373 existing tests pass
- [x] No changes to test expectations needed
- [x] Added `warn` mock to test infrastructure for `_handleError` logging