### PR TITLE
feat: Add editorconfig, FirmwareRevision characteristic, and gitignore updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# JavaScript files
+[*.js]
+indent_size = 4
+
+# JSON files
+[*.json]
+indent_size = 4
+
+# YAML files (2 spaces is standard for YAML)
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown files (preserve trailing spaces for line breaks)
+[*.md]
+trim_trailing_whitespace = false
+
+# Package manager lock files (preserve as-is)
+[package-lock.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
+# Local temporary folder contents
+tmp
+
+# Claude Code local files
+.claude/settings.local.json
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ lerna-debug.log*
 .pnpm-debug.log*
 
 # Local temporary folder contents
-tmp
+tmp/
 
 # Claude Code local files
 .claude/settings.local.json

--- a/src/accessories/accessory.js
+++ b/src/accessories/accessory.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const airstage = require('./../airstage');
+const settings = require('./../settings');
 
 class Accessory {
 
@@ -18,7 +19,8 @@ class Accessory {
         this.accessory.getService(this.Service.AccessoryInformation)
             .setCharacteristic(this.Characteristic.Manufacturer, airstage.constants.MANUFACTURER_FUJITSU)
             .setCharacteristic(this.Characteristic.Model, this.accessory.context.model)
-            .setCharacteristic(this.Characteristic.SerialNumber, this.accessory.context.deviceId);
+            .setCharacteristic(this.Characteristic.SerialNumber, this.accessory.context.deviceId)
+            .setCharacteristic(this.Characteristic.FirmwareRevision, settings.PLUGIN_VERSION);
     }
 
     _refreshDynamicServiceCharacteristics() {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,4 +1,7 @@
 'use strict';
 
+const { version } = require('../package.json');
+
 module.exports.PLATFORM_NAME = 'fujitsu-airstage';
 module.exports.PLUGIN_NAME = 'homebridge-fujitsu-airstage';
+module.exports.PLUGIN_VERSION = version;

--- a/test/accessories/test-fan-accessory.js
+++ b/test/accessories/test-fan-accessory.js
@@ -35,6 +35,24 @@ test('FanAccessory#constructor registers accessory', (context) => {
     mockHomebridge.resetMocks();
 });
 
+test('FanAccessory#constructor sets FirmwareRevision to plugin version', (context) => {
+    const settings = require('../../src/settings');
+    new FanAccessory(
+        mockHomebridge.platform,
+        platformAccessory
+    );
+
+    const firmwareCall = mockHomebridge.service.setCharacteristic.mock.calls.find(
+        (call) => call.arguments[0] === mockHomebridge.platform.Characteristic.FirmwareRevision
+    );
+
+    assert.notStrictEqual(firmwareCall, undefined, 'FirmwareRevision should be set');
+    assert.strictEqual(firmwareCall.arguments[1], settings.PLUGIN_VERSION);
+    assert.ok(typeof settings.PLUGIN_VERSION === 'string' && settings.PLUGIN_VERSION.length > 0);
+
+    mockHomebridge.resetMocks();
+});
+
 test('FanAccessory#constructor configures event listeners', (context) => {
     const fanAccessory = new FanAccessory(
         mockHomebridge.platform,


### PR DESCRIPTION
## Summary

- Adds `.editorconfig` for consistent formatting across editors (4-space indent for JS/JSON, 2-space for YAML, as discussed in PR #34)
- Exposes the plugin version as the `FirmwareRevision` characteristic in HomeKit accessories
- Adds `tmp/` and `.claude/settings.local.json` to `.gitignore`

## Context

This is **PR 3 of 3** from the original PR #34, split as requested. The three PRs are:
1. Error handling & StatusFault reporting (independent)
2. Local LAN connection mode (depends on PR 1)
3. **This PR** - Developer experience improvements (independent)

**Note:** The `.editorconfig` file is added but NOT applied to existing files (the mass-format commit from PR #34 has been excluded). This just establishes the config for future edits.

## Test Plan

- [x] All 373 existing tests pass
- [x] No formatting changes to existing files