### PR TITLE
Move shared cloud/LAN API constants from `airstage.apiv1.constants` to `airstage.constants`

### DIFF
--- a/src/airstage/cloud/apiv1/constants.js
+++ b/src/airstage/cloud/apiv1/constants.js
@@ -44,36 +44,6 @@ module.exports.METADATA_KEYS = [
     module.exports.METADATA_DEVICE_NAME
 ];
 
-// Parameter names
-module.exports.PARAMETER_MODEL = 'iu_model';
-module.exports.PARAMETER_FAN_SPEED = 'iu_fan_spd';
-module.exports.PARAMETER_ON_OFF = 'iu_onoff'
-module.exports.PARAMETER_SET_TEMPERATURE = 'iu_set_tmp';
-module.exports.PARAMETER_INDOOR_TEMPERATURE = 'iu_indoor_tmp';
-module.exports.PARAMETER_OPERATION_MODE = 'iu_op_mode';
-module.exports.PARAMETER_FAN_SPEED = 'iu_fan_spd';
-module.exports.PARAMETER_AIRFLOW_VERTICAL_DIRECTION = 'iu_af_dir_vrt';
-module.exports.PARAMETER_AIRFLOW_VERTICAL_SWING = 'iu_af_swg_vrt';
-module.exports.PARAMETER_POWERFUL = 'iu_powerful';
-module.exports.PARAMETER_ECONOMY = 'iu_economy';
-module.exports.PARAMETER_ENERGY_SAVING_FAN = 'iu_fan_ctrl';
-module.exports.PARAMETER_MINIMUM_HEAT = 'iu_min_heat';
-
-// Parameter values
-module.exports.PARAMETER_ON = '1';
-module.exports.PARAMETER_OFF = '0';
-module.exports.PARAMETER_NOT_AVAILABLE = '65535';
-module.exports.PARAMETER_OPERATION_MODE_AUTO = '0';
-module.exports.PARAMETER_OPERATION_MODE_COOL = '1';
-module.exports.PARAMETER_OPERATION_MODE_DRY = '2';
-module.exports.PARAMETER_OPERATION_MODE_FAN = '3';
-module.exports.PARAMETER_OPERATION_MODE_HEAT = '4';
-module.exports.PARAMETER_FAN_SPEED_AUTO = '0';
-module.exports.PARAMETER_FAN_SPEED_QUIET = '2';
-module.exports.PARAMETER_FAN_SPEED_LOW = '5';
-module.exports.PARAMETER_FAN_SPEED_MEDIUM = '8';
-module.exports.PARAMETER_FAN_SPEED_HIGH = '11';
-
 // Parameter statuses
 module.exports.PARAMETER_STATUS_WAITING = 'waiting';
 module.exports.PARAMETER_STATUS_COMPLETE = 'complete';
@@ -87,10 +57,6 @@ module.exports.USER_TEMPERATURE_SCALE = 'tempUnit';
 // Message codes
 module.exports.MESSAGE_CODE_INVALID_LOGIN = 'AIRSTAGE_POST_USERS_SIGNIN_EMAIL_PASSWORD_INVALID';
 module.exports.MESSAGE_CODE_INVALID_TOKEN = 'AIRSTAGE_COMMON_TOKEN_INVALID';
-
-// Temperature scales
-module.exports.TEMPERATURE_SCALE_FAHRENHEIT = 'F';
-module.exports.TEMPERATURE_SCALE_CELSIUS = 'C';
 
 // Request header templates
 module.exports.REQUEST_HEADERS_POST_PUT = {

--- a/src/airstage/cloud/client.js
+++ b/src/airstage/cloud/client.js
@@ -172,7 +172,7 @@ class Client {
     getModel(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_MODEL,
+            constants.PARAMETER_MODEL,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -188,7 +188,7 @@ class Client {
     getPowerState(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_ON_OFF,
+            constants.PARAMETER_ON_OFF,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -208,7 +208,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_ON_OFF,
+            constants.PARAMETER_ON_OFF,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -219,7 +219,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToToggle(
-                        device.parameters[apiv1.constants.PARAMETER_ON_OFF]
+                        device.parameters[constants.PARAMETER_ON_OFF]
                     );
                 }
 
@@ -231,7 +231,7 @@ class Client {
     getOperationMode(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_OPERATION_MODE,
+            constants.PARAMETER_OPERATION_MODE,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -251,7 +251,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_OPERATION_MODE,
+            constants.PARAMETER_OPERATION_MODE,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -270,8 +270,8 @@ class Client {
                         {
                             'parameters': [
                                 {
-                                    'name': apiv1.constants.PARAMETER_FAN_SPEED,
-                                    'value': apiv1.constants.PARAMETER_FAN_SPEED_AUTO
+                                    'name': constants.PARAMETER_FAN_SPEED,
+                                    'value': constants.PARAMETER_FAN_SPEED_AUTO
                                 }
                             ]
                         }
@@ -280,7 +280,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToOperationMode(
-                        device.parameters[apiv1.constants.PARAMETER_OPERATION_MODE]
+                        device.parameters[constants.PARAMETER_OPERATION_MODE]
                     );
                 }
 
@@ -292,7 +292,7 @@ class Client {
     getIndoorTemperature(deviceId, scale, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_INDOOR_TEMPERATURE,
+            constants.PARAMETER_INDOOR_TEMPERATURE,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -303,7 +303,7 @@ class Client {
                 if (parameterValue !== null) {
                     result = this._indoorIntValueToTemperature(parameterValue);
 
-                    if (scale === apiv1.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+                    if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
                         result = this._celsiusToFahrenheit(result);
                     }
                 }
@@ -316,7 +316,7 @@ class Client {
     getTargetTemperature(deviceId, scale, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_SET_TEMPERATURE,
+            constants.PARAMETER_SET_TEMPERATURE,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -326,7 +326,7 @@ class Client {
 
                 result = this._intValueToTemperature(parameterValue);
 
-                if (scale === apiv1.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+                if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
                     result = this._celsiusToFahrenheit(result);
                 }
 
@@ -338,12 +338,12 @@ class Client {
     setTargetTemperature(deviceId, temperature, scale, callback) {
         let intValue = null;
 
-        if (scale === apiv1.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+        if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
             temperature = this._fahrenheitToCelsius(temperature);
-        } else if (scale === apiv1.constants.TEMPERATURE_SCALE_CELSIUS) {
+        } else if (scale === constants.TEMPERATURE_SCALE_CELSIUS) {
             temperature = this._getClosestValidTemperature(
                 temperature,
-                apiv1.constants.TEMPERATURE_SCALE_CELSIUS
+                constants.TEMPERATURE_SCALE_CELSIUS
             );
         }
 
@@ -351,7 +351,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_SET_TEMPERATURE,
+            constants.PARAMETER_SET_TEMPERATURE,
             intValue.toString(),
             (function(error, device) {
                 let result = null;
@@ -362,10 +362,10 @@ class Client {
                 }
 
                 if (device.parameters) {
-                    parameterValue = device.parameters[apiv1.constants.PARAMETER_SET_TEMPERATURE];
+                    parameterValue = device.parameters[constants.PARAMETER_SET_TEMPERATURE];
                     result = this._intValueToTemperature(parameterValue);
 
-                    if (scale === apiv1.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+                    if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
                         result = this._celsiusToFahrenheit(result);
                     }
                 }
@@ -398,7 +398,7 @@ class Client {
     getFanSpeed(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_FAN_SPEED,
+            constants.PARAMETER_FAN_SPEED,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -418,7 +418,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_FAN_SPEED,
+            constants.PARAMETER_FAN_SPEED,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -429,7 +429,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToFanSpeed(
-                        device.parameters[apiv1.constants.PARAMETER_FAN_SPEED]
+                        device.parameters[constants.PARAMETER_FAN_SPEED]
                     );
                 }
 
@@ -441,7 +441,7 @@ class Client {
     getAirflowVerticalDirection(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION,
+            constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -463,7 +463,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION,
+            constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -474,7 +474,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._validateAirflowVerticalDirectionValue(
-                        parseInt(device.parameters[apiv1.constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION])
+                        parseInt(device.parameters[constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION])
                     );
                 }
 
@@ -486,7 +486,7 @@ class Client {
     getAirflowVerticalSwingState(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_AIRFLOW_VERTICAL_SWING,
+            constants.PARAMETER_AIRFLOW_VERTICAL_SWING,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -506,7 +506,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_AIRFLOW_VERTICAL_SWING,
+            constants.PARAMETER_AIRFLOW_VERTICAL_SWING,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -517,7 +517,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToToggle(
-                        device.parameters[apiv1.constants.PARAMETER_AIRFLOW_VERTICAL_SWING]
+                        device.parameters[constants.PARAMETER_AIRFLOW_VERTICAL_SWING]
                     );
                 }
 
@@ -529,7 +529,7 @@ class Client {
     getPowerfulState(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_POWERFUL,
+            constants.PARAMETER_POWERFUL,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -549,7 +549,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_POWERFUL,
+            constants.PARAMETER_POWERFUL,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -560,7 +560,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToToggle(
-                        device.parameters[apiv1.constants.PARAMETER_POWERFUL]
+                        device.parameters[constants.PARAMETER_POWERFUL]
                     );
                 }
 
@@ -572,7 +572,7 @@ class Client {
     getEconomyState(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_ECONOMY,
+            constants.PARAMETER_ECONOMY,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -592,7 +592,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_ECONOMY,
+            constants.PARAMETER_ECONOMY,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -603,7 +603,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToToggle(
-                        device.parameters[apiv1.constants.PARAMETER_ECONOMY]
+                        device.parameters[constants.PARAMETER_ECONOMY]
                     );
                 }
 
@@ -615,7 +615,7 @@ class Client {
     getEnergySavingFanState(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_ENERGY_SAVING_FAN,
+            constants.PARAMETER_ENERGY_SAVING_FAN,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -635,7 +635,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_ENERGY_SAVING_FAN,
+            constants.PARAMETER_ENERGY_SAVING_FAN,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -646,7 +646,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToToggle(
-                        device.parameters[apiv1.constants.PARAMETER_ENERGY_SAVING_FAN]
+                        device.parameters[constants.PARAMETER_ENERGY_SAVING_FAN]
                     );
                 }
 
@@ -658,7 +658,7 @@ class Client {
     getMinimumHeatState(deviceId, callback) {
         this.getParameter(
             deviceId,
-            apiv1.constants.PARAMETER_MINIMUM_HEAT,
+            constants.PARAMETER_MINIMUM_HEAT,
             (function(error, parameterValue) {
                 let result = null;
 
@@ -678,7 +678,7 @@ class Client {
 
         this.setParameter(
             deviceId,
-            apiv1.constants.PARAMETER_MINIMUM_HEAT,
+            constants.PARAMETER_MINIMUM_HEAT,
             parameterValue,
             (function(error, device) {
                 let result = null;
@@ -700,19 +700,19 @@ class Client {
                         {
                             'parameters': [
                                 {
-                                    'name': apiv1.constants.PARAMETER_ON_OFF,
-                                    'value': apiv1.constants.PARAMETER_ON
+                                    'name': constants.PARAMETER_ON_OFF,
+                                    'value': constants.PARAMETER_ON
                                 },
                                 {
-                                    'name': apiv1.constants.PARAMETER_FAN_SPEED,
-                                    'value': apiv1.constants.PARAMETER_FAN_SPEED_AUTO
+                                    'name': constants.PARAMETER_FAN_SPEED,
+                                    'value': constants.PARAMETER_FAN_SPEED_AUTO
                                 },
                                 {
-                                    'name': apiv1.constants.PARAMETER_OPERATION_MODE,
-                                    'value': apiv1.constants.PARAMETER_OPERATION_MODE_HEAT
+                                    'name': constants.PARAMETER_OPERATION_MODE,
+                                    'value': constants.PARAMETER_OPERATION_MODE_HEAT
                                 },
                                 {
-                                    'name': apiv1.constants.PARAMETER_SET_TEMPERATURE,
+                                    'name': constants.PARAMETER_SET_TEMPERATURE,
                                     'value': '100'
                                 }
                             ]
@@ -728,8 +728,8 @@ class Client {
                         {
                             'parameters': [
                                 {
-                                    'name': apiv1.constants.PARAMETER_ON_OFF,
-                                    'value': apiv1.constants.PARAMETER_OFF
+                                    'name': constants.PARAMETER_ON_OFF,
+                                    'value': constants.PARAMETER_OFF
                                 }
                             ]
                         }
@@ -738,7 +738,7 @@ class Client {
 
                 if (device.parameters) {
                     result = this._parameterValueToToggle(
-                        device.parameters[apiv1.constants.PARAMETER_MINIMUM_HEAT]
+                        device.parameters[constants.PARAMETER_MINIMUM_HEAT]
                     );
                 }
 
@@ -1057,7 +1057,7 @@ class Client {
                     parameterName = parameter.name;
                 }
 
-                if (parameter.value !== apiv1.constants.PARAMETER_NOT_AVAILABLE) {
+                if (parameter.value !== constants.PARAMETER_NOT_AVAILABLE) {
                     parameterValue = parameter.value;
                 }
 
@@ -1175,11 +1175,11 @@ class Client {
     _getClosestValidTemperature(temperature, scale) {
         let closestTemperature = null;
 
-        if (scale === apiv1.constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+        if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
             closestTemperature = constants.VALID_FAHRENHEIT_VALUES.reduce(function(x, y) {
                 return (Math.abs(y - temperature) < Math.abs(x - temperature) ? y : x);
             });
-        } else if (scale === apiv1.constants.TEMPERATURE_SCALE_CELSIUS) {
+        } else if (scale === constants.TEMPERATURE_SCALE_CELSIUS) {
             closestTemperature = constants.VALID_CELSIUS_VALUES.reduce(function(x, y) {
                 return (Math.abs(y - temperature) < Math.abs(x - temperature) ? y : x);
             });
@@ -1203,7 +1203,7 @@ class Client {
     _fahrenheitToCelsius(fahrenheit) {
         const closestFahrenheit = this._getClosestValidTemperature(
             fahrenheit,
-            apiv1.constants.TEMPERATURE_SCALE_FAHRENHEIT
+            constants.TEMPERATURE_SCALE_FAHRENHEIT
         );
 
         return constants.FAHRENHEIT_TO_CELSIUS_MAP[closestFahrenheit];
@@ -1212,7 +1212,7 @@ class Client {
     _celsiusToFahrenheit(celsius) {
         const closestCelsius = this._getClosestValidTemperature(
             celsius,
-            apiv1.constants.TEMPERATURE_SCALE_CELSIUS
+            constants.TEMPERATURE_SCALE_CELSIUS
         );
 
         return constants.CELSIUS_TO_FAHRENHEIT_MAP[closestCelsius];

--- a/src/airstage/constants.js
+++ b/src/airstage/constants.js
@@ -1,9 +1,53 @@
 'use strict';
 
-const apiv1 = require('./cloud/apiv1');
-
 // Manufacturer
 module.exports.MANUFACTURER_FUJITSU = 'Fujitsu';
+
+// Parameter names
+module.exports.PARAMETER_MODEL = 'iu_model';
+module.exports.PARAMETER_FAN_SPEED = 'iu_fan_spd';
+module.exports.PARAMETER_ON_OFF = 'iu_onoff'
+module.exports.PARAMETER_SET_TEMPERATURE = 'iu_set_tmp';
+module.exports.PARAMETER_INDOOR_TEMPERATURE = 'iu_indoor_tmp';
+module.exports.PARAMETER_OPERATION_MODE = 'iu_op_mode';
+module.exports.PARAMETER_FAN_SPEED = 'iu_fan_spd';
+module.exports.PARAMETER_AIRFLOW_VERTICAL_DIRECTION = 'iu_af_dir_vrt';
+module.exports.PARAMETER_AIRFLOW_VERTICAL_SWING = 'iu_af_swg_vrt';
+module.exports.PARAMETER_POWERFUL = 'iu_powerful';
+module.exports.PARAMETER_ECONOMY = 'iu_economy';
+module.exports.PARAMETER_ENERGY_SAVING_FAN = 'iu_fan_ctrl';
+module.exports.PARAMETER_MINIMUM_HEAT = 'iu_min_heat';
+
+module.exports.ALL_PARAMETERS = [
+    module.exports.PARAMETER_MODEL,
+    module.exports.PARAMETER_FAN_SPEED,
+    module.exports.PARAMETER_ON_OFF,
+    module.exports.PARAMETER_SET_TEMPERATURE,
+    module.exports.PARAMETER_INDOOR_TEMPERATURE,
+    module.exports.PARAMETER_OPERATION_MODE,
+    module.exports.PARAMETER_FAN_SPEED,
+    module.exports.PARAMETER_AIRFLOW_VERTICAL_DIRECTION,
+    module.exports.PARAMETER_AIRFLOW_VERTICAL_SWING,
+    module.exports.PARAMETER_POWERFUL,
+    module.exports.PARAMETER_ECONOMY,
+    module.exports.PARAMETER_ENERGY_SAVING_FAN,
+    module.exports.PARAMETER_MINIMUM_HEAT
+];
+
+// Parameter values
+module.exports.PARAMETER_ON = '1';
+module.exports.PARAMETER_OFF = '0';
+module.exports.PARAMETER_NOT_AVAILABLE = '65535';
+module.exports.PARAMETER_OPERATION_MODE_AUTO = '0';
+module.exports.PARAMETER_OPERATION_MODE_COOL = '1';
+module.exports.PARAMETER_OPERATION_MODE_DRY = '2';
+module.exports.PARAMETER_OPERATION_MODE_FAN = '3';
+module.exports.PARAMETER_OPERATION_MODE_HEAT = '4';
+module.exports.PARAMETER_FAN_SPEED_AUTO = '0';
+module.exports.PARAMETER_FAN_SPEED_QUIET = '2';
+module.exports.PARAMETER_FAN_SPEED_LOW = '5';
+module.exports.PARAMETER_FAN_SPEED_MEDIUM = '8';
+module.exports.PARAMETER_FAN_SPEED_HIGH = '11';
 
 // Operation modes
 module.exports.OPERATION_MODE_AUTO = 'AUTO';
@@ -21,18 +65,18 @@ module.exports.OPERATION_MODES = [
 ];
 
 module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP = {};
-module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_AUTO] = apiv1.constants.PARAMETER_OPERATION_MODE_AUTO;
-module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_COOL] = apiv1.constants.PARAMETER_OPERATION_MODE_COOL;
-module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_DRY] = apiv1.constants.PARAMETER_OPERATION_MODE_DRY;
-module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_FAN] = apiv1.constants.PARAMETER_OPERATION_MODE_FAN;
-module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_HEAT] = apiv1.constants.PARAMETER_OPERATION_MODE_HEAT;
+module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_AUTO] = module.exports.PARAMETER_OPERATION_MODE_AUTO;
+module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_COOL] = module.exports.PARAMETER_OPERATION_MODE_COOL;
+module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_DRY] = module.exports.PARAMETER_OPERATION_MODE_DRY;
+module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_FAN] = module.exports.PARAMETER_OPERATION_MODE_FAN;
+module.exports.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[module.exports.OPERATION_MODE_HEAT] = module.exports.PARAMETER_OPERATION_MODE_HEAT;
 
 module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP = {};
-module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[apiv1.constants.PARAMETER_OPERATION_MODE_AUTO] = module.exports.OPERATION_MODE_AUTO;
-module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[apiv1.constants.PARAMETER_OPERATION_MODE_COOL] = module.exports.OPERATION_MODE_COOL;
-module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[apiv1.constants.PARAMETER_OPERATION_MODE_DRY] = module.exports.OPERATION_MODE_DRY;
-module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[apiv1.constants.PARAMETER_OPERATION_MODE_FAN] = module.exports.OPERATION_MODE_FAN;
-module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[apiv1.constants.PARAMETER_OPERATION_MODE_HEAT] = module.exports.OPERATION_MODE_HEAT;
+module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[module.exports.PARAMETER_OPERATION_MODE_AUTO] = module.exports.OPERATION_MODE_AUTO;
+module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[module.exports.PARAMETER_OPERATION_MODE_COOL] = module.exports.OPERATION_MODE_COOL;
+module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[module.exports.PARAMETER_OPERATION_MODE_DRY] = module.exports.OPERATION_MODE_DRY;
+module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[module.exports.PARAMETER_OPERATION_MODE_FAN] = module.exports.OPERATION_MODE_FAN;
+module.exports.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[module.exports.PARAMETER_OPERATION_MODE_HEAT] = module.exports.OPERATION_MODE_HEAT;
 
 // Fan speeds
 module.exports.FAN_SPEED_AUTO = 'AUTO';
@@ -50,18 +94,18 @@ module.exports.FAN_SPEEDS = [
 ];
 
 module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP = {};
-module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_AUTO] = apiv1.constants.PARAMETER_FAN_SPEED_AUTO;
-module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_QUIET] = apiv1.constants.PARAMETER_FAN_SPEED_QUIET;
-module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_LOW] = apiv1.constants.PARAMETER_FAN_SPEED_LOW;
-module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_MEDIUM] = apiv1.constants.PARAMETER_FAN_SPEED_MEDIUM;
-module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_HIGH] = apiv1.constants.PARAMETER_FAN_SPEED_HIGH;
+module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_AUTO] = module.exports.PARAMETER_FAN_SPEED_AUTO;
+module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_QUIET] = module.exports.PARAMETER_FAN_SPEED_QUIET;
+module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_LOW] = module.exports.PARAMETER_FAN_SPEED_LOW;
+module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_MEDIUM] = module.exports.PARAMETER_FAN_SPEED_MEDIUM;
+module.exports.FAN_SPEED_TO_PARAMETER_VALUE_MAP[module.exports.FAN_SPEED_HIGH] = module.exports.PARAMETER_FAN_SPEED_HIGH;
 
 module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP = {};
-module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[apiv1.constants.PARAMETER_FAN_SPEED_AUTO] = module.exports.FAN_SPEED_AUTO;
-module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[apiv1.constants.PARAMETER_FAN_SPEED_QUIET] = module.exports.FAN_SPEED_QUIET;
-module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[apiv1.constants.PARAMETER_FAN_SPEED_LOW] = module.exports.FAN_SPEED_LOW;
-module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[apiv1.constants.PARAMETER_FAN_SPEED_MEDIUM] = module.exports.FAN_SPEED_MEDIUM;
-module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[apiv1.constants.PARAMETER_FAN_SPEED_HIGH] = module.exports.FAN_SPEED_HIGH;
+module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[module.exports.PARAMETER_FAN_SPEED_AUTO] = module.exports.FAN_SPEED_AUTO;
+module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[module.exports.PARAMETER_FAN_SPEED_QUIET] = module.exports.FAN_SPEED_QUIET;
+module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[module.exports.PARAMETER_FAN_SPEED_LOW] = module.exports.FAN_SPEED_LOW;
+module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[module.exports.PARAMETER_FAN_SPEED_MEDIUM] = module.exports.FAN_SPEED_MEDIUM;
+module.exports.PARAMETER_VALUE_TO_FAN_SPEED_MAP[module.exports.PARAMETER_FAN_SPEED_HIGH] = module.exports.FAN_SPEED_HIGH;
 
 // Toggle values
 module.exports.TOGGLE_ON = 'ON';
@@ -73,20 +117,25 @@ module.exports.TOGGLE_VALUES = [
 ];
 
 module.exports.TOGGLE_TO_PARAMETER_VALUE_MAP = {};
-module.exports.TOGGLE_TO_PARAMETER_VALUE_MAP[module.exports.TOGGLE_ON] = apiv1.constants.PARAMETER_ON;
-module.exports.TOGGLE_TO_PARAMETER_VALUE_MAP[module.exports.TOGGLE_OFF] = apiv1.constants.PARAMETER_OFF;
+module.exports.TOGGLE_TO_PARAMETER_VALUE_MAP[module.exports.TOGGLE_ON] = module.exports.PARAMETER_ON;
+module.exports.TOGGLE_TO_PARAMETER_VALUE_MAP[module.exports.TOGGLE_OFF] = module.exports.PARAMETER_OFF;
 
 module.exports.PARAMETER_VALUE_TO_TOGGLE_MAP = {};
-module.exports.PARAMETER_VALUE_TO_TOGGLE_MAP[apiv1.constants.PARAMETER_ON] = module.exports.TOGGLE_ON;
-module.exports.PARAMETER_VALUE_TO_TOGGLE_MAP[apiv1.constants.PARAMETER_OFF] = module.exports.TOGGLE_OFF;
+module.exports.PARAMETER_VALUE_TO_TOGGLE_MAP[module.exports.PARAMETER_ON] = module.exports.TOGGLE_ON;
+module.exports.PARAMETER_VALUE_TO_TOGGLE_MAP[module.exports.PARAMETER_OFF] = module.exports.TOGGLE_OFF;
 
 // Airflow vertical directions
 module.exports.MIN_AIRFLOW_VERTICAL_DIRECTION = 1;
 module.exports.MAX_AIRFLOW_VERTICAL_DIRECTION = 4;
 
 // Temperatures
-module.exports.TEMPERATURE_SCALE_FAHRENHEIT = apiv1.constants.TEMPERATURE_SCALE_FAHRENHEIT;
-module.exports.TEMPERATURE_SCALE_CELSIUS = apiv1.constants.TEMPERATURE_SCALE_CELSIUS;
+module.exports.TEMPERATURE_SCALE_CELSIUS = 'C';
+module.exports.TEMPERATURE_SCALE_FAHRENHEIT = 'F';
+
+module.exports.TEMPERATURE_SCALES = [
+    module.exports.TEMPERATURE_SCALE_CELSIUS,
+    module.exports.TEMPERATURE_SCALE_FAHRENHEIT
+];
 
 module.exports.FAHRENHEIT_TO_CELSIUS_MAP = {
     50: 10.0,

--- a/src/platform.js
+++ b/src/platform.js
@@ -124,7 +124,7 @@ class Platform {
                     const deviceMetadata = devices.metadata[deviceId];
                     const deviceParameters = devices.parameters[deviceId];
                     const deviceName = deviceMetadata.deviceName;
-                    const model = deviceParameters[airstage.cloud.apiv1.constants.PARAMETER_MODEL] || 'Airstage';
+                    const model = deviceParameters[airstage.constants.PARAMETER_MODEL] || 'Airstage';
 
                     this._configureAirstageDevice(
                         deviceId,


### PR DESCRIPTION
These will be referenced in both `airstage.cloud.apiv1` and `airstage.lan.api`, so let's move them to the shared `airstage.constants` file