### PR TITLE
Add `airstage.lan.client`, `airstage.lan.api.client`

### DIFF
--- a/src/airstage/constants.js
+++ b/src/airstage/constants.js
@@ -18,7 +18,7 @@ module.exports.PARAMETER_ECONOMY = 'iu_economy';
 module.exports.PARAMETER_ENERGY_SAVING_FAN = 'iu_fan_ctrl';
 module.exports.PARAMETER_MINIMUM_HEAT = 'iu_min_heat';
 
-module.exports.ALL_PARAMETERS = [
+module.exports.PARAMETER_NAMES = [
     module.exports.PARAMETER_MODEL,
     module.exports.PARAMETER_FAN_SPEED,
     module.exports.PARAMETER_ON_OFF,

--- a/src/airstage/index.js
+++ b/src/airstage/index.js
@@ -2,5 +2,6 @@
 
 const cloud = require('./cloud');
 const constants = require('./constants');
+const lan = require('./lan');
 
-module.exports = { cloud, constants };
+module.exports = { cloud, constants, lan };

--- a/src/airstage/lan/api/client.js
+++ b/src/airstage/lan/api/client.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const http = require('node:http');
+const constants = require('./constants');
+
+class Client {
+
+    constructor(
+        userAgent = null
+    ) {
+        this.userAgent = userAgent || constants.DEFAULT_USER_AGENT;
+    }
+
+    // POST http://[hostname]/GetParam
+    postGetParam(hostname, deviceId, deviceSubId, list, callback) {
+        const requestBody = {
+            'device_id': deviceId,
+            'device_sub_id': deviceSubId,
+            'req_id': '',
+            'modified_by': '',
+            'set_level': constants.SET_LEVEL_GET,
+            'list': list
+        };
+
+        this._makePostRequest(
+            hostname,
+            constants.PATH_GET_PARAM,
+            requestBody,
+            callback
+        );
+    }
+
+    // POST http://[hostname]/SetParam
+    postSetParam(hostname, deviceId, deviceSubId, value, callback) {
+        const requestBody = {
+            'device_id': deviceId,
+            'device_sub_id': deviceSubId,
+            'req_id': '',
+            'modified_by': '',
+            'set_level': constants.SET_LEVEL_SET,
+            'value': value
+        };
+
+        this._makePostRequest(
+            hostname,
+            constants.PATH_SET_PARAM,
+            requestBody,
+            callback
+        );
+    }
+
+    _makePostRequest(hostname, path, requestBody, callback) {
+        this._makeRequestWithRequestBody(
+            constants.REQUEST_METHOD_POST,
+            hostname,
+            path,
+            requestBody,
+            callback
+        );
+    }
+
+    _makeRequestWithRequestBody(method, hostname, path, requestBody, callback) {
+        const requestBodyJson = JSON.stringify(requestBody);
+        let request = null;
+        let requestOptions = null;
+        let requestHeaders = structuredClone(constants.REQUEST_HEADERS_POST);
+
+        requestHeaders[constants.REQUEST_HEADER_USER_AGENT] = this.userAgent;
+        requestHeaders[constants.REQUEST_HEADER_CONTENT_LENGTH] = requestBodyJson.length;
+
+        requestOptions = {
+            'hostname': hostname,
+            'path': path,
+            'method': method,
+            'headers': requestHeaders
+        };
+
+        this._makeHttpRequest(requestOptions, requestBodyJson, callback);
+    }
+
+    _makeHttpRequest(requestOptions, requestBodyJson, callback) {
+        let result = structuredClone(constants.REQUEST_RESULT);
+
+        const request = http.request(requestOptions, (response) => {
+            result.statusCode = response.statusCode;
+
+            response.on('data', (chunk) => {
+                result.response += chunk;
+            });
+
+            response.on('end', () => {
+                if (result.response) {
+                    result.response = JSON.parse(result.response);
+                }
+
+                callback(result);
+            });
+        }).on('error', (error) => {
+            result.error = error;
+            callback(result);
+        });
+
+        if (requestBodyJson) {
+            request.write(requestBodyJson);
+        }
+
+        request.end();
+    }
+}
+
+module.exports = Client;

--- a/src/airstage/lan/api/constants.js
+++ b/src/airstage/lan/api/constants.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// Default values
+module.exports.DEFAULT_USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+
+// API endpoint paths
+module.exports.PATH_GET_PARAM = '/GetParam';
+module.exports.PATH_SET_PARAM = '/SetParam';
+
+// Request methods
+module.exports.REQUEST_METHOD_POST = 'POST';
+
+// Set level values
+module.exports.SET_LEVEL_GET = '03';
+module.exports.SET_LEVEL_SET = '02';
+
+// Request header keys
+module.exports.REQUEST_HEADER_AUTHORIZATION = 'authorization';
+module.exports.REQUEST_HEADER_CONTENT_LENGTH = 'content-length';
+module.exports.REQUEST_HEADER_USER_AGENT = 'user-agent';
+
+// Parameter results
+module.exports.PARAMETER_RESULT_SUCCESS = 'OK';
+
+// Request header templates
+module.exports.REQUEST_HEADERS_POST = {
+    'content-type': 'application/json',
+    'accept': 'application/json, text/plain, */*',
+    'sec-fetch-site': 'cross-site',
+    'accept-encoding': 'gzip, deflate, br',
+    'accept-language': 'en-US,en;q=0.9',
+    'sec-fetch-mode': 'cors',
+    'origin': 'file://',
+    'sec-fetch-dest': 'empty'
+};
+
+// Result template
+module.exports.REQUEST_RESULT = {
+    'error': null,
+    'statusCode': null,
+    'response': ''
+};

--- a/src/airstage/lan/api/index.js
+++ b/src/airstage/lan/api/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const Client = require('./client');
+const constants = require('./constants');
+
+module.exports = { Client, constants };

--- a/src/airstage/lan/client.js
+++ b/src/airstage/lan/client.js
@@ -1,0 +1,981 @@
+'use strict';
+
+const api = require('./api');
+const constants = require('./../constants');
+
+class Client {
+
+    constructor(
+        localDevices,
+        temperatureScalePreference,
+        userAgent = null
+    ) {
+        this.localDevices = localDevices;
+        this.temperatureScalePreference = temperatureScalePreference;
+
+        this._apiClient = new api.Client(
+            userAgent || null
+        );
+
+        this.resetDeviceCache();
+        this._setDeviceIdToLocalDeviceMap();
+    }
+
+    getTemperatureScale(callback) {
+        if (constants.TEMPERATURE_SCALES.includes(this.temperatureScalePreference) === false) {
+            return callback('Invalid temperature scale: ' + this.temperatureScalePreference, null);
+        }
+
+        callback(null, this.temperatureScalePreference);
+    }
+
+    setTemperatureScale(scale, callback) {
+        if (constants.TEMPERATURE_SCALES.includes(scale) === false) {
+            return callback('Invalid temperature scale: ' + scale, null);
+        }
+
+        this.temperatureScalePreference = scale;
+
+        callback(null, this.temperatureScalePreference);
+    }
+
+    getName(deviceId, callback) {
+        const displayName = this._getDisplayNameForDeviceId(deviceId);
+
+        if (displayName === null) {
+            return callback('Could not determine name for device ID: ' + deviceId, null);
+        }
+
+        callback(null, displayName);
+    }
+
+    getModel(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_MODEL,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                callback(null, parameterValue);
+            }).bind(this)
+        );
+    }
+
+    getPowerState(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_ON_OFF,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToToggle(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setPowerState(deviceId, toggle, callback) {
+        const parameterValue = this._toggleToParameterValue(toggle);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_ON_OFF,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToToggle(
+                        device.parameters[constants.PARAMETER_ON_OFF]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getOperationMode(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_OPERATION_MODE,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToOperationMode(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setOperationMode(deviceId, operationMode, callback) {
+        const parameterValue = this._operationModeToParameterValue(operationMode);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_OPERATION_MODE,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (operationMode === constants.OPERATION_MODE_DRY) {
+                    // These things automatically happen on the device side
+                    // when turning on dry mode, so let's update
+                    // them in the local device cache:
+                    // - The fan speed is set to "AUTO"
+                    this._setDeviceParameterCache(
+                        deviceId,
+                        {
+                            'parameters': [
+                                {
+                                    'name': constants.PARAMETER_FAN_SPEED,
+                                    'value': constants.PARAMETER_FAN_SPEED_AUTO
+                                }
+                            ]
+                        }
+                    );
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToOperationMode(
+                        device.parameters[constants.PARAMETER_OPERATION_MODE]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getIndoorTemperature(deviceId, scale, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_INDOOR_TEMPERATURE,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (parameterValue !== null) {
+                    result = this._indoorIntValueToTemperature(parameterValue);
+
+                    if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+                        result = this._celsiusToFahrenheit(result);
+                    }
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getTargetTemperature(deviceId, scale, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_SET_TEMPERATURE,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._intValueToTemperature(parameterValue);
+
+                if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+                    result = this._celsiusToFahrenheit(result);
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setTargetTemperature(deviceId, temperature, scale, callback) {
+        let intValue = null;
+
+        if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+            temperature = this._fahrenheitToCelsius(temperature);
+        } else if (scale === constants.TEMPERATURE_SCALE_CELSIUS) {
+            temperature = this._getClosestValidTemperature(
+                temperature,
+                constants.TEMPERATURE_SCALE_CELSIUS
+            );
+        }
+
+        intValue = this._temperatureToIntValue(temperature);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_SET_TEMPERATURE,
+            intValue.toString(),
+            (function(error, device) {
+                let result = null;
+                let parameterValue = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    parameterValue = device.parameters[constants.PARAMETER_SET_TEMPERATURE];
+                    result = this._intValueToTemperature(parameterValue);
+
+                    if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+                        result = this._celsiusToFahrenheit(result);
+                    }
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getTemperatureDelta(deviceId, scale, callback) {
+        this.getIndoorTemperature(deviceId, scale, (function(error, indoorTemperature) {
+            if (error) {
+                return callback(error, null);
+            }
+
+            this.getTargetTemperature(deviceId, scale, (function(error, targetTemperature) {
+                let temperatureDelta = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                temperatureDelta = (indoorTemperature - targetTemperature);
+
+                callback(null, temperatureDelta);
+            }).bind(this));
+        }).bind(this));
+    }
+
+    getFanSpeed(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_FAN_SPEED,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToFanSpeed(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setFanSpeed(deviceId, fanSpeed, callback) {
+        const parameterValue = this._fanSpeedToParameterValue(fanSpeed);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_FAN_SPEED,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToFanSpeed(
+                        device.parameters[constants.PARAMETER_FAN_SPEED]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getAirflowVerticalDirection(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._validateAirflowVerticalDirectionValue(
+                    parseInt(parameterValue)
+                );
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setAirflowVerticalDirection(deviceId, value, callback) {
+        const parameterValue = this._validateAirflowVerticalDirectionValue(value).toString();
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    result = this._validateAirflowVerticalDirectionValue(
+                        parseInt(device.parameters[constants.PARAMETER_AIRFLOW_VERTICAL_DIRECTION])
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getAirflowVerticalSwingState(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_AIRFLOW_VERTICAL_SWING,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToToggle(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setAirflowVerticalSwingState(deviceId, toggle, callback) {
+        const parameterValue = this._toggleToParameterValue(toggle);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_AIRFLOW_VERTICAL_SWING,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToToggle(
+                        device.parameters[constants.PARAMETER_AIRFLOW_VERTICAL_SWING]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getPowerfulState(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_POWERFUL,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToToggle(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setPowerfulState(deviceId, toggle, callback) {
+        const parameterValue = this._toggleToParameterValue(toggle);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_POWERFUL,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToToggle(
+                        device.parameters[constants.PARAMETER_POWERFUL]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getEconomyState(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_ECONOMY,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToToggle(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setEconomyState(deviceId, toggle, callback) {
+        const parameterValue = this._toggleToParameterValue(toggle);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_ECONOMY,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToToggle(
+                        device.parameters[constants.PARAMETER_ECONOMY]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getEnergySavingFanState(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_ENERGY_SAVING_FAN,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToToggle(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setEnergySavingFanState(deviceId, toggle, callback) {
+        const parameterValue = this._toggleToParameterValue(toggle);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_ENERGY_SAVING_FAN,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToToggle(
+                        device.parameters[constants.PARAMETER_ENERGY_SAVING_FAN]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getMinimumHeatState(deviceId, callback) {
+        this.getParameter(
+            deviceId,
+            constants.PARAMETER_MINIMUM_HEAT,
+            (function(error, parameterValue) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                result = this._parameterValueToToggle(parameterValue);
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    setMinimumHeatState(deviceId, toggle, callback) {
+        const parameterValue = this._toggleToParameterValue(toggle);
+
+        this.setParameter(
+            deviceId,
+            constants.PARAMETER_MINIMUM_HEAT,
+            parameterValue,
+            (function(error, device) {
+                let result = null;
+
+                if (error) {
+                    return callback(error, null);
+                }
+
+                if (toggle === constants.TOGGLE_ON) {
+                    // These things automatically happen on the device side
+                    // when turning on minimum heat, so let's update
+                    // them in the local device cache:
+                    // - The power state is set to "ON"
+                    // - The fan speed is set to "AUTO"
+                    // - The operation mode is set to "HEAT"
+                    // - The temperature is set to 10 degrees (C)
+                    this._setDeviceParameterCache(
+                        deviceId,
+                        {
+                            'parameters': [
+                                {
+                                    'name': constants.PARAMETER_ON_OFF,
+                                    'value': constants.PARAMETER_ON
+                                },
+                                {
+                                    'name': constants.PARAMETER_FAN_SPEED,
+                                    'value': constants.PARAMETER_FAN_SPEED_AUTO
+                                },
+                                {
+                                    'name': constants.PARAMETER_OPERATION_MODE,
+                                    'value': constants.PARAMETER_OPERATION_MODE_HEAT
+                                },
+                                {
+                                    'name': constants.PARAMETER_SET_TEMPERATURE,
+                                    'value': '100'
+                                }
+                            ]
+                        }
+                    );
+                } else if (toggle === constants.TOGGLE_OFF) {
+                    // These things automatically happen on the device side
+                    // when turning off minimum heat, so let's update
+                    // them in the local device cache:
+                    // - The power state is set to "OFF"
+                    this._setDeviceParameterCache(
+                        deviceId,
+                        {
+                            'parameters': [
+                                {
+                                    'name': constants.PARAMETER_ON_OFF,
+                                    'value': constants.PARAMETER_OFF
+                                }
+                            ]
+                        }
+                    );
+                }
+
+                if (device.parameters) {
+                    result = this._parameterValueToToggle(
+                        device.parameters[constants.PARAMETER_MINIMUM_HEAT]
+                    );
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    getParameter(deviceId, name, callback) {
+        this.getDevice(deviceId, function(error, device) {
+            let result = null;
+
+            if (error) {
+                return callback(error, null);
+            }
+
+            if (device.parameters) {
+                result = device.parameters[name];
+            }
+
+            if (result === null || result === undefined) {
+                return callback('Parameter not available: ' + name, null);
+            }
+
+            callback(null, result);
+        });
+    }
+
+    setParameter(deviceId, name, value, callback) {
+        const deviceSubId = '0';
+        const hostname = this._getHostnameForDeviceId(deviceId);
+
+        if (hostname === null) {
+            return callback('No hostname for device ID: ' + deviceId, null);
+        }
+
+        const postSetParamValue = {};
+        postSetParamValue[name] = value;
+
+        this._apiClient.postSetParam(
+            hostname,
+            deviceId,
+            deviceSubId,
+            postSetParamValue,
+            (function(result) {
+                if (result.error) {
+                    return callback(result.error, null);
+                }
+
+                let deviceParameters = null;
+
+                if (result.response.value) {
+                    const device = {
+                        'parameters': []
+                    };
+
+                    Object.keys(result.response.value).forEach(function(parameterName) {
+                        device.parameters.push({
+                            'name': parameterName,
+                            'value': result.response.value[parameterName]
+                        });
+                    }, this);
+
+                    deviceParameters = this._setDeviceParameterCache(deviceId, device);
+                }
+
+                callback(null, {
+                    'parameters': deviceParameters
+                });
+            }).bind(this)
+        );
+    }
+
+    getDevices(limit, callback) {
+        const devicesFromCache = this._getDevicesFromCache();
+        const isCacheHit = (
+            devicesFromCache.parameters &&
+            Object.keys(devicesFromCache.parameters).length > 0
+        );
+
+        if (isCacheHit) {
+            return callback(null, devicesFromCache);
+        }
+
+        this._getDevicesFromApi(callback);
+    }
+
+    getDevice(deviceId, callback) {
+        const deviceFromCache = this._getDeviceFromCache(deviceId);
+        const isCacheHit = (
+            deviceFromCache.parameters !== null
+        );
+
+        if (isCacheHit) {
+            return callback(null, deviceFromCache);
+        }
+
+        this._getDeviceFromApi(deviceId, callback);
+    }
+
+    resetDeviceCache(deviceId = null) {
+        if (deviceId === null) {
+            this._deviceParameterCache = {};
+        } else {
+            if (deviceId in this._deviceParameterCache) {
+                delete this._deviceParameterCache[deviceId];
+            }
+        }
+    }
+
+    refreshDeviceCache(callback) {
+        this._getDevicesFromApi(
+            (function(error, result) {
+                if (error) {
+                    return callback(error, null);
+                }
+
+                callback(null, result);
+            }).bind(this)
+        );
+    }
+
+    _setDeviceIdToLocalDeviceMap() {
+        this._deviceIdToLocalDeviceMap = {};
+
+        this.localDevices.forEach(function(localDevice) {
+            const deviceId = localDevice.macAddress.replaceAll(':', '').toUpperCase();
+
+            this._deviceIdToLocalDeviceMap[deviceId] = localDevice;
+        }, this);
+    }
+
+    _getHostnameForDeviceId(deviceId) {
+        let hostname = null;
+
+        if (deviceId in this._deviceIdToLocalDeviceMap) {
+            hostname = this._deviceIdToLocalDeviceMap[deviceId].hostname;
+        }
+
+        return hostname;
+    }
+
+    _getDisplayNameForDeviceId(deviceId) {
+        let displayName = null;
+
+        if (deviceId in this._deviceIdToLocalDeviceMap) {
+            displayName = this._deviceIdToLocalDeviceMap[deviceId].displayName;
+        }
+
+        return displayName;
+    }
+
+    _getDeviceParameterCache(deviceId) {
+        let result = null;
+
+        if (deviceId === null) {
+            result = this._deviceParameterCache;
+        } else if (deviceId in this._deviceParameterCache) {
+            result = this._deviceParameterCache[deviceId];
+        }
+
+        return result;
+    }
+
+    _setDeviceParameterCache(deviceId, device) {
+        if ((deviceId in this._deviceParameterCache) === false) {
+            this._deviceParameterCache[deviceId] = {};
+        }
+
+        if (device && 'parameters' in device) {
+            device.parameters.forEach(function(parameter) {
+                let parameterName = null;
+                let parameterValue = null;
+
+                if (parameter.name) {
+                    parameterName = parameter.name;
+                }
+
+                if (parameter.value !== constants.PARAMETER_NOT_AVAILABLE) {
+                    parameterValue = parameter.value;
+                }
+
+                if (parameterName) {
+                    this._deviceParameterCache[deviceId][parameterName] = parameterValue;
+                }
+            }, this);
+        }
+
+        return this._getDeviceParameterCache(deviceId);
+    }
+
+    _getDevicesFromCache() {
+        return this._getDeviceFromCache(null);
+    }
+
+    _getDevicesFromApi(callback) {
+        const deviceIds = Object.keys(this._deviceIdToLocalDeviceMap);
+        const errors = {};
+
+        let numRequests = deviceIds.length;
+
+        for (let i = 0; i < deviceIds.length; i++) {
+            const deviceId = deviceIds[i];
+            this._getDeviceFromApi(
+                deviceId,
+                (function(error, result) {
+                    if (error) {
+                        errors[deviceId] = error;
+                    }
+
+                    numRequests -= 1;
+                }).bind(this)
+            );
+        }
+
+        while (numRequests !== 0) {
+            // No-op, waiting for all of the requests to finish
+        }
+
+        if (Object.keys(errors).length !== 0) {
+            return callback(errors, null);
+        }
+
+        const deviceParameters = this._getDeviceParameterCache(null);
+
+        callback(null, {
+            'parameters': deviceParameters
+        });
+    }
+
+    _getDeviceFromCache(deviceId) {
+        return {
+            'parameters' : this._getDeviceParameterCache(deviceId)
+        };
+    }
+
+    _getDeviceFromApi(deviceId, callback) {
+        const deviceSubId = '0';
+        const hostname = this._getHostnameForDeviceId(deviceId);
+
+        if (hostname === null) {
+            return callback('No hostname for device ID: ' + deviceId, null);
+        }
+
+        this._apiClient.postGetParam(
+            hostname,
+            deviceId,
+            deviceSubId,
+            constants.PARAMETER_NAMES,
+            (function(result) {
+                if (result.error) {
+                    return callback(result.error, null);
+                }
+
+                let deviceParameters = null;
+
+                if (result.response.value) {
+                    const device = {
+                        'parameters': []
+                    };
+
+                    Object.keys(result.response.value).forEach(function(parameterName) {
+                        device.parameters.push({
+                            'name': parameterName,
+                            'value': result.response.value[parameterName]
+                        });
+                    }, this);
+
+                    deviceParameters = this._setDeviceParameterCache(deviceId, device);
+                }
+
+                callback(null, {
+                    'parameters': deviceParameters
+                });
+            }).bind(this)
+        );
+    }
+
+    _getClosestValidTemperature(temperature, scale) {
+        let closestTemperature = null;
+
+        if (scale === constants.TEMPERATURE_SCALE_FAHRENHEIT) {
+            closestTemperature = constants.VALID_FAHRENHEIT_VALUES.reduce(function(x, y) {
+                return (Math.abs(y - temperature) < Math.abs(x - temperature) ? y : x);
+            });
+        } else if (scale === constants.TEMPERATURE_SCALE_CELSIUS) {
+            closestTemperature = constants.VALID_CELSIUS_VALUES.reduce(function(x, y) {
+                return (Math.abs(y - temperature) < Math.abs(x - temperature) ? y : x);
+            });
+        }
+
+        return closestTemperature;
+    }
+
+    _temperatureToIntValue(temperature) {
+        return (temperature * 10);
+    }
+
+    _indoorIntValueToTemperature(intValue) {
+        return ((intValue - 5000) / 100);
+    }
+
+    _intValueToTemperature(intValue) {
+        return (intValue / 10);
+    }
+
+    _fahrenheitToCelsius(fahrenheit) {
+        const closestFahrenheit = this._getClosestValidTemperature(
+            fahrenheit,
+            constants.TEMPERATURE_SCALE_FAHRENHEIT
+        );
+
+        return constants.FAHRENHEIT_TO_CELSIUS_MAP[closestFahrenheit];
+    }
+
+    _celsiusToFahrenheit(celsius) {
+        const closestCelsius = this._getClosestValidTemperature(
+            celsius,
+            constants.TEMPERATURE_SCALE_CELSIUS
+        );
+
+        return constants.CELSIUS_TO_FAHRENHEIT_MAP[closestCelsius];
+    }
+
+    _operationModeToParameterValue(operationMode) {
+        return constants.OPERATION_MODE_TO_PARAMETER_VALUE_MAP[operationMode];
+    }
+
+    _parameterValueToOperationMode(parameterValue) {
+        return constants.PARAMETER_VALUE_TO_OPERATION_MODE_MAP[parameterValue];
+    }
+
+    _fanSpeedToParameterValue(fanSpeed) {
+        return constants.FAN_SPEED_TO_PARAMETER_VALUE_MAP[fanSpeed];
+    }
+
+    _parameterValueToFanSpeed(parameterValue) {
+        return constants.PARAMETER_VALUE_TO_FAN_SPEED_MAP[parameterValue];
+    }
+
+    _toggleToParameterValue(toggle) {
+        return constants.TOGGLE_TO_PARAMETER_VALUE_MAP[toggle];
+    }
+
+    _parameterValueToToggle(parameterValue) {
+        return constants.PARAMETER_VALUE_TO_TOGGLE_MAP[parameterValue];
+    }
+
+    _validateAirflowVerticalDirectionValue(value) {
+        if (value < constants.MIN_AIRFLOW_VERTICAL_DIRECTION) {
+            value = constants.MIN_AIRFLOW_VERTICAL_DIRECTION;
+        } else if (value > constants.MAX_AIRFLOW_VERTICAL_DIRECTION) {
+            value = constants.MAX_AIRFLOW_VERTICAL_DIRECTION;
+        }
+
+        return value;
+    }
+}
+
+module.exports = Client;

--- a/src/airstage/lan/index.js
+++ b/src/airstage/lan/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const api = require('./api');
+const Client = require('./client');
+
+module.exports = { api, Client };

--- a/test/airstage/lan/api/test-client.js
+++ b/test/airstage/lan/api/test-client.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mock, test } = require('node:test');
+const airstage = require('./../../../../src/airstage');
+
+const client = new airstage.lan.api.Client();
+
+test('airstage.lan.api.Client#postGetParam calls _makeHttpRequest with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_fan_spd': '0'
+        },
+        'read_res': 'ack',
+        'device_id': '1CCE512CA9C9',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        client,
+        '_makeHttpRequest',
+        (requestOptions, requestBodyJson, callback) => {
+            let result = structuredClone(airstage.lan.api.constants.REQUEST_RESULT);
+            result.response = expectedResponse;
+
+            callback(result);
+        }
+    );
+    context.after(() => {
+        const mockedMethod = client._makeHttpRequest.mock;
+        const requestOptions = mockedMethod.calls[0].arguments[0];
+        const requestBody = JSON.parse(mockedMethod.calls[0].arguments[1]);
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(requestOptions.method, 'POST');
+        assert.strictEqual(requestOptions.hostname, '127.0.0.1');
+        assert.strictEqual(requestOptions.path, '/GetParam');
+        assert.strictEqual(requestBody.device_id, '1CCE512CA9C9');
+        assert.strictEqual(requestBody.device_sub_id, '0');
+        assert.strictEqual(requestBody.req_id, '');
+        assert.strictEqual(requestBody.modified_by, '');
+        assert.strictEqual(requestBody.set_level, '03');
+        assert.strictEqual(requestBody.list.length, 1);
+        assert.strictEqual(requestBody.list[0], 'iu_fan_spd');
+    });
+
+    client.postGetParam('127.0.0.1', '1CCE512CA9C9', '0', ['iu_fan_spd'], (result) => {
+        assert.strictEqual(result.error, null);
+        assert.strictEqual(result.response, expectedResponse);
+
+        done();
+    });
+});
+
+test('airstage.lan.api.Client#postGetParam calls _makeHttpRequest with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        client,
+        '_makeHttpRequest',
+        (requestOptions, requestBodyJson, callback) => {
+            let result = structuredClone(airstage.lan.api.constants.REQUEST_RESULT);
+            result.error = expectedError;
+
+            callback(result);
+        }
+    );
+    context.after(() => {
+        const mockedMethod = client._makeHttpRequest.mock;
+        const requestOptions = mockedMethod.calls[0].arguments[0];
+        const requestBody = JSON.parse(mockedMethod.calls[0].arguments[1]);
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(requestOptions.method, 'POST');
+        assert.strictEqual(requestOptions.hostname, '127.0.0.1');
+        assert.strictEqual(requestOptions.path, '/GetParam');
+        assert.strictEqual(requestBody.device_id, '1CCE512CA9C9');
+        assert.strictEqual(requestBody.device_sub_id, '0');
+        assert.strictEqual(requestBody.req_id, '');
+        assert.strictEqual(requestBody.modified_by, '');
+        assert.strictEqual(requestBody.set_level, '03');
+        assert.strictEqual(requestBody.list.length, 1);
+        assert.strictEqual(requestBody.list[0], 'iu_fan_spd');
+    });
+
+    client.postGetParam('127.0.0.1', '1CCE512CA9C9', '0', ['iu_fan_spd'], (result) => {
+        assert.strictEqual(result.error, expectedError);
+        assert.strictEqual(result.response, '');
+
+        done();
+    });
+});
+
+test('airstage.lan.api.Client#postSetParam calls _makeHttpRequest with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_onoff': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '1CCE512CA9C9',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        client,
+        '_makeHttpRequest',
+        (requestOptions, requestBodyJson, callback) => {
+            let result = structuredClone(airstage.lan.api.constants.REQUEST_RESULT);
+            result.response = expectedResponse;
+
+            callback(result);
+        }
+    );
+    context.after(() => {
+        const mockedMethod = client._makeHttpRequest.mock;
+        const requestOptions = mockedMethod.calls[0].arguments[0];
+        const requestBody = JSON.parse(mockedMethod.calls[0].arguments[1]);
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(requestOptions.method, 'POST');
+        assert.strictEqual(requestOptions.hostname, '127.0.0.1');
+        assert.strictEqual(requestOptions.path, '/SetParam');
+        assert.strictEqual(requestBody.device_id, '1CCE512CA9C9');
+        assert.strictEqual(requestBody.device_sub_id, '0');
+        assert.strictEqual(requestBody.req_id, '');
+        assert.strictEqual(requestBody.modified_by, '');
+        assert.strictEqual(requestBody.set_level, '02');
+        assert.strictEqual(Object.keys(requestBody.value).length, 1);
+        assert.strictEqual(requestBody.value['iu_fan_spd'], '1');
+    });
+
+    client.postSetParam('127.0.0.1', '1CCE512CA9C9', '0', {'iu_fan_spd': '1'}, (result) => {
+        assert.strictEqual(result.error, null);
+        assert.strictEqual(result.response, expectedResponse);
+
+        done();
+    });
+});
+
+test('airstage.lan.api.Client#postSetParam calls _makeHttpRequest with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        client,
+        '_makeHttpRequest',
+        (requestOptions, requestBodyJson, callback) => {
+            let result = structuredClone(airstage.lan.api.constants.REQUEST_RESULT);
+            result.error = expectedError;
+
+            callback(result);
+        }
+    );
+    context.after(() => {
+        const mockedMethod = client._makeHttpRequest.mock;
+        const requestOptions = mockedMethod.calls[0].arguments[0];
+        const requestBody = JSON.parse(mockedMethod.calls[0].arguments[1]);
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(requestOptions.method, 'POST');
+        assert.strictEqual(requestOptions.hostname, '127.0.0.1');
+        assert.strictEqual(requestOptions.path, '/SetParam');
+        assert.strictEqual(requestBody.device_id, '1CCE512CA9C9');
+        assert.strictEqual(requestBody.device_sub_id, '0');
+        assert.strictEqual(requestBody.req_id, '');
+        assert.strictEqual(requestBody.modified_by, '');
+        assert.strictEqual(requestBody.set_level, '02');
+        assert.strictEqual(Object.keys(requestBody.value).length, 1);
+        assert.strictEqual(requestBody.value['iu_fan_spd'], '1');
+    });
+
+    client.postSetParam('127.0.0.1', '1CCE512CA9C9', '0', {'iu_fan_spd': '1'}, (result) => {
+        assert.strictEqual(result.error, expectedError);
+        assert.strictEqual(result.response, '');
+
+        done();
+    });
+});

--- a/test/airstage/lan/test-client.js
+++ b/test/airstage/lan/test-client.js
@@ -1,0 +1,2285 @@
+'use strict';
+
+const assert = require('node:assert');
+const { mock, test } = require('node:test');
+const airstage = require('./../../../src/airstage');
+
+const clientWithCelsius = new airstage.lan.Client(
+    [
+        {
+            hostname: '1.2.3.4',
+            macAddress: '39:FF:BB:9D:6E:BA',
+            displayName: 'Air Conditioner'
+        },
+        {
+            hostname: '2.3.4.5',
+            macAddress: '96:65:8F:1B:F6:01',
+            displayName: 'Heat Pump'
+        }
+    ],
+    'C'
+);
+const clientWithFahrenheit = new airstage.lan.Client(
+    [
+        {
+            hostname: '1.2.3.4',
+            macAddress: '39:FF:BB:9D:6E:BA',
+            displayName: 'Air Conditioner'
+        },
+        {
+            hostname: '2.3.4.5',
+            macAddress: '96:65:8F:1B:F6:01',
+            displayName: 'Heat Pump'
+        }
+    ],
+    'F'
+);
+const clientWithInvalidTemperatureScale = new airstage.lan.Client(
+    [
+        {
+            hostname: '1.2.3.4',
+            macAddress: '39:FF:BB:9D:6E:BA',
+            displayName: 'Air Conditioner'
+        },
+        {
+            hostname: '2.3.4.5',
+            macAddress: '96:65:8F:1B:F6:01',
+            displayName: 'Heat Pump'
+        }
+    ],
+    'K'
+);
+
+test('airstage.lan.Client#getTemperatureScale with success', (context, done) => {
+    clientWithFahrenheit.getTemperatureScale((error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'F');
+
+        done();
+    });
+});
+
+test('airstage.cloud.Client#getTemperatureScale with error', (context, done) => {
+    const expectedError = 'Invalid temperature scale: K';
+
+    clientWithInvalidTemperatureScale.getTemperatureScale((error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setTemperatureScale with success', (context, done) => {
+    clientWithFahrenheit.setTemperatureScale('F', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'F');
+
+        done();
+    });
+});
+
+test('airstage.cloud.Client#setTemperatureScale with error', (context, done) => {
+    const expectedError = 'Invalid temperature scale: K';
+
+    clientWithInvalidTemperatureScale.setTemperatureScale('K', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getName with success', (context, done) => {
+    clientWithFahrenheit.getName('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'Air Conditioner');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getName with error', (context, done) => {
+    const expectedError = 'Could not determine name for device ID: ASDF';
+
+    clientWithFahrenheit.getName('ASDF', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getModel calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_model': 'AZ123'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getModel('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'AZ123');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getModel calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getModel('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getPowerState calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_onoff': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getPowerState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getPowerState calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getPowerState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setPowerState calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_onoff': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_onoff'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setPowerState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setPowerState calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_onoff'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setPowerState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getOperationMode calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_op_mode': '0'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getOperationMode('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'AUTO');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getOperationMode calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getOperationMode('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setOperationMode with "COOL" calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_op_mode': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_op_mode'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setOperationMode('39FFBB9D6EBA', 'COOL', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'COOL');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setOperationMode with "DRY" calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_op_mode': '2'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_op_mode'], '2');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setOperationMode('39FFBB9D6EBA', 'DRY', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'DRY');
+
+        clientWithFahrenheit.getDevice('39FFBB9D6EBA', (error, result) => {
+            assert.strictEqual(error, null);
+            assert.strictEqual(Object.keys(result.parameters).length, 2);
+            assert.strictEqual(result.parameters['iu_fan_spd'], '0');
+            assert.strictEqual(result.parameters['iu_op_mode'], '2');
+
+            done();
+        });
+    });
+});
+
+test('airstage.lan.Client#setOperationMode calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_op_mode'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setOperationMode('39FFBB9D6EBA', 'COOL', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getIndoorTemperature calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_indoor_tmp': '7200'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getIndoorTemperature('39FFBB9D6EBA', 'F', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 72);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getIndoorTemperature calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getIndoorTemperature('39FFBB9D6EBA', 'F', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getTargetTemperature calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_set_tmp': '220'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getTargetTemperature('39FFBB9D6EBA', 'F', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 72);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getTargetTemperature calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getTargetTemperature('39FFBB9D6EBA', 'F', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setTargetTemperature with "F" calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_set_tmp': '220'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_set_tmp'], '220');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setTargetTemperature('39FFBB9D6EBA', 72, 'F', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 72);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setTargetTemperature with "C" calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_set_tmp': '220'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithCelsius._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithCelsius._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_set_tmp'], '220');
+    });
+    clientWithCelsius.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithCelsius.setTargetTemperature('39FFBB9D6EBA', 22, 'C', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 22);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setTargetTemperature calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_set_tmp'], '220');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setTargetTemperature('39FFBB9D6EBA', 72, 'F', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getTemperatureDelta calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_indoor_tmp': '7400',
+            'iu_set_tmp': '220'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getTemperatureDelta('39FFBB9D6EBA', 'F', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 4);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getTemperatureDelta calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getTemperatureDelta('39FFBB9D6EBA', 'F', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getFanSpeed calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_fan_spd': '11'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getFanSpeed('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'HIGH');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getFanSpeed calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getFanSpeed('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setFanSpeed calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_fan_spd': '11'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_fan_spd'], '11');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setFanSpeed('39FFBB9D6EBA', 'HIGH', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'HIGH');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setFanSpeed calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_fan_spd'], '11');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setFanSpeed('39FFBB9D6EBA', 'HIGH', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getAirflowVerticalDirection calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_af_dir_vrt': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getAirflowVerticalDirection('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 1);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getAirflowVerticalDirection calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getAirflowVerticalDirection('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setAirflowVerticalDirection with 0 calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_af_dir_vrt': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_af_dir_vrt'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setAirflowVerticalDirection('39FFBB9D6EBA', 0, (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 1);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setAirflowVerticalDirection with 1 calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_af_dir_vrt': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_af_dir_vrt'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setAirflowVerticalDirection('39FFBB9D6EBA', 1, (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 1);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setAirflowVerticalDirection with 5 calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_af_dir_vrt': '4'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_af_dir_vrt'], '4');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setAirflowVerticalDirection('39FFBB9D6EBA', 5, (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 4);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setAirflowVerticalDirection calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_af_dir_vrt'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setAirflowVerticalDirection('39FFBB9D6EBA', 1, (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getAirflowVerticalSwingState calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_af_swg_vrt': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getAirflowVerticalSwingState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getAirflowVerticalSwingState calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getAirflowVerticalSwingState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setAirflowVerticalSwingState calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_af_swg_vrt': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_af_swg_vrt'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setAirflowVerticalSwingState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setAirflowVerticalSwingState calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_af_swg_vrt'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setAirflowVerticalSwingState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getPowerfulState calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_powerful': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getPowerfulState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getPowerfulState calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getPowerfulState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setPowerfulState calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_powerful': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_powerful'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setPowerfulState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setPowerfulState calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_powerful'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setPowerfulState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getEconomyState calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_economy': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getEconomyState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getEconomyState calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getEconomyState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setEconomyState calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_economy': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_economy'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setEconomyState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setEconomyState calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_economy'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setEconomyState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getEnergySavingFanState calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_fan_ctrl': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getEnergySavingFanState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getEnergySavingFanState calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getEnergySavingFanState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setEnergySavingFanState calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_fan_ctrl': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_fan_ctrl'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setEnergySavingFanState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setEnergySavingFanState calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_fan_ctrl'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setEnergySavingFanState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getMinimumHeatState calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_min_heat': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getMinimumHeatState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getMinimumHeatState calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getMinimumHeatState('39FFBB9D6EBA', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setMinimumHeatState with "ON" calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_min_heat': '1'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_min_heat'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setMinimumHeatState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'ON');
+
+        clientWithFahrenheit.getDevice('39FFBB9D6EBA', (error, result) => {
+            assert.strictEqual(error, null);
+            assert.strictEqual(Object.keys(result.parameters).length, 5);
+            assert.strictEqual(result.parameters['iu_min_heat'], '1');
+            assert.strictEqual(result.parameters['iu_onoff'], '1');
+            assert.strictEqual(result.parameters['iu_fan_spd'], '0');
+            assert.strictEqual(result.parameters['iu_op_mode'], '4');
+            assert.strictEqual(result.parameters['iu_set_tmp'], '100');
+
+            done();
+        });
+    });
+});
+
+test('airstage.lan.Client#setMinimumHeatState with "OFF" calls _apiClient.postSetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_min_heat': '0'
+        },
+        'write_res': 'ack',
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '02',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_min_heat'], '0');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setMinimumHeatState('39FFBB9D6EBA', 'OFF', (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(result, 'OFF');
+
+        clientWithFahrenheit.getDevice('39FFBB9D6EBA', (error, result) => {
+            assert.strictEqual(error, null);
+            assert.strictEqual(Object.keys(result.parameters).length, 2);
+            assert.strictEqual(result.parameters['iu_min_heat'], '0');
+            assert.strictEqual(result.parameters['iu_onoff'], '0');
+
+            done();
+        });
+    });
+});
+
+test('airstage.lan.Client#setMinimumHeatState calls _apiClient.postSetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postSetParam',
+        (hostname, deviceId, deviceSubId, value, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postSetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(Object.keys(mockedMethod.calls[0].arguments[3]).length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments[3]['iu_min_heat'], '1');
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.setMinimumHeatState('39FFBB9D6EBA', 'ON', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getParameter with null parameter calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Parameter not available: iu_min_heat';
+    const expectedResponse = {
+        'value': {
+            'iu_min_heat': null
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getParameter('39FFBB9D6EBA', 'iu_min_heat', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getParameter with undefined parameter calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Parameter not available: foo';
+    const expectedResponse = {
+        'value': {
+            'iu_min_heat': '1'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 1);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache('39FFBB9D6EBA');
+
+    clientWithFahrenheit.getParameter('39FFBB9D6EBA', 'foo', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#setParameter with unknown device ID returns error', (context, done) => {
+    const expectedError = 'No hostname for device ID: foo';
+
+    clientWithFahrenheit.setParameter('foo', 'iu_min_heat', '1', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getDevice with unknown device ID returns error', (context, done) => {
+    const expectedError = 'No hostname for device ID: foo';
+
+    clientWithFahrenheit.getDevice('foo', (error, result) => {
+        assert.strictEqual(error, expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getDevices with cache hit returns devices', (context, done) => {
+    clientWithFahrenheit.resetDeviceCache();
+    clientWithFahrenheit._setDeviceParameterCache('39FFBB9D6EBA', {'parameters': [{'name': 'iu_min_heat', 'value': '1'}]});
+    clientWithFahrenheit._setDeviceParameterCache('96658F1BF601', {'parameters': [{'name': 'iu_min_heat', 'value': '0'}]});
+
+    clientWithFahrenheit.getDevices(0, (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(Object.keys(result).length, 1);
+        assert.strictEqual(Object.keys(result.parameters).length, 2);
+        assert.strictEqual(Object.keys(result.parameters['39FFBB9D6EBA']).length, 1);
+        assert.strictEqual(result.parameters['39FFBB9D6EBA']['iu_min_heat'], '1');
+        assert.strictEqual(Object.keys(result.parameters['96658F1BF601']).length, 1);
+        assert.strictEqual(result.parameters['96658F1BF601']['iu_min_heat'], '0');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#getDevices without cache hit calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_model': 'AZ123'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 2);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+        assert.strictEqual(mockedMethod.calls[1].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[1].arguments[0], '2.3.4.5');
+        assert.strictEqual(mockedMethod.calls[1].arguments[1], '96658F1BF601');
+        assert.strictEqual(mockedMethod.calls[1].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[1].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache();
+
+    clientWithFahrenheit.getDevices(0, (error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(Object.keys(result).length, 1);
+        assert.strictEqual(Object.keys(result.parameters).length, 2);
+        assert.strictEqual(Object.keys(result.parameters['39FFBB9D6EBA']).length, 1);
+        assert.strictEqual(result.parameters['39FFBB9D6EBA']['iu_model'], 'AZ123');
+        assert.strictEqual(Object.keys(result.parameters['96658F1BF601']).length, 1);
+        assert.strictEqual(result.parameters['96658F1BF601']['iu_model'], 'AZ123');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#refreshDeviceCache calls _apiClient.postGetParam with success', (context, done) => {
+    const expectedResponse = {
+        'value': {
+            'iu_model': 'AZ123'
+        },
+        'read_res': 'ack',
+        'device_id': '39FFBB9D6EBA',
+        'device_sub_id': 0,
+        'req_id': '',
+        'modified_by': '',
+        'set_level': '03',
+        'cause': '',
+        'result': 'OK',
+        'error': ''
+    };
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': null, 'response': expectedResponse});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 2);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+        assert.strictEqual(mockedMethod.calls[1].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[1].arguments[0], '2.3.4.5');
+        assert.strictEqual(mockedMethod.calls[1].arguments[1], '96658F1BF601');
+        assert.strictEqual(mockedMethod.calls[1].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[1].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache();
+
+    clientWithFahrenheit.refreshDeviceCache((error, result) => {
+        assert.strictEqual(error, null);
+        assert.strictEqual(Object.keys(result).length, 1);
+        assert.strictEqual(Object.keys(result.parameters).length, 2);
+        assert.strictEqual(Object.keys(result.parameters['39FFBB9D6EBA']).length, 1);
+        assert.strictEqual(result.parameters['39FFBB9D6EBA']['iu_model'], 'AZ123');
+        assert.strictEqual(Object.keys(result.parameters['96658F1BF601']).length, 1);
+        assert.strictEqual(result.parameters['96658F1BF601']['iu_model'], 'AZ123');
+
+        done();
+    });
+});
+
+test('airstage.lan.Client#refreshDeviceCache calls _apiClient.postGetParam with error', (context, done) => {
+    const expectedError = 'Error';
+    context.mock.method(
+        clientWithFahrenheit._apiClient,
+        'postGetParam',
+        (hostname, deviceId, deviceSubId, list, callback) => {
+            callback({'error': expectedError, 'response': null});
+        }
+    );
+    context.after(() => {
+        const mockedMethod = clientWithFahrenheit._apiClient.postGetParam.mock;
+
+        assert.strictEqual(mockedMethod.calls.length, 2);
+        assert.strictEqual(mockedMethod.calls[0].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[0].arguments[0], '1.2.3.4');
+        assert.strictEqual(mockedMethod.calls[0].arguments[1], '39FFBB9D6EBA');
+        assert.strictEqual(mockedMethod.calls[0].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[0].arguments[3], airstage.constants.PARAMETER_NAMES);
+        assert.strictEqual(mockedMethod.calls[1].arguments.length, 5);
+        assert.strictEqual(mockedMethod.calls[1].arguments[0], '2.3.4.5');
+        assert.strictEqual(mockedMethod.calls[1].arguments[1], '96658F1BF601');
+        assert.strictEqual(mockedMethod.calls[1].arguments[2], '0');
+        assert.strictEqual(mockedMethod.calls[1].arguments[3], airstage.constants.PARAMETER_NAMES);
+    });
+    clientWithFahrenheit.resetDeviceCache();
+
+    clientWithFahrenheit.refreshDeviceCache((error, result) => {
+        assert.strictEqual(Object.keys(error).length, 2);
+        assert.strictEqual(error['39FFBB9D6EBA'], expectedError);
+        assert.strictEqual(error['96658F1BF601'], expectedError);
+        assert.strictEqual(result, null);
+
+        done();
+    });
+});


### PR DESCRIPTION
Based off of #34, original idea and implementation by @rbonestell (added as a co-author to the commits).

IMO, this is the easiest way to integrate LAN device management, and have it live side-by-side with the existing cloud device management. This PR introduces an `airstage.lan.client` that is (nearly) functionally identical to the `airstage.cloud.client`, so that both can be used interchangeably by the Homebridge plugin code.