### PR TITLE
Add 30 second timeout to HTTP requests in API clients

### DIFF
--- a/src/airstage/cloud/apiv1/client.js
+++ b/src/airstage/cloud/apiv1/client.js
@@ -263,7 +263,8 @@ class Client {
             'hostname': null,
             'path': path,
             'method': method,
-            'headers': requestHeaders
+            'headers': requestHeaders,
+            'timeout': 30000 // 30 seconds
         };
 
         this._makeHttpsRequest(requestOptions, requestBodyJson, callback);
@@ -298,6 +299,11 @@ class Client {
         }).on('error', (error) => {
             result.error = error;
             callback(result);
+        }).on('timeout', () => {
+            result.error = 'Request timeout';
+            callback(result);
+
+            request.destroy();
         });
 
         if (requestBodyJson) {

--- a/src/airstage/lan/api/client.js
+++ b/src/airstage/lan/api/client.js
@@ -72,7 +72,8 @@ class Client {
             'hostname': hostname,
             'path': path,
             'method': method,
-            'headers': requestHeaders
+            'headers': requestHeaders,
+            'timeout': 30000 // 30 seconds
         };
 
         this._makeHttpRequest(requestOptions, requestBodyJson, callback);
@@ -98,6 +99,11 @@ class Client {
         }).on('error', (error) => {
             result.error = error;
             callback(result);
+        }).on('timeout', () => {
+            result.error = 'Request timeout';
+            callback(result);
+
+            request.destroy();
         });
 
         if (requestBodyJson) {


### PR DESCRIPTION
This is useful if someone incorrectly adds a LAN device, but also if the Airstage API is hanging for whatever reason.