### PR TITLE
Update supported Homebridge and Node versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/PatrickStankard/homebridge-fujitsu-airstage/issues"
   },
   "engines": {
-    "node": "^18 || ^20 || ^22",
-    "homebridge": "^1.6.0 || ^2.0.0-beta.0"
+    "node": "^18 || ^20 || ^22 || ^24 || ^26",
+    "homebridge": "^1.6.0 || ^2.0.0"
   },
   "main": "src/index.js",
   "scripts": {
@@ -32,8 +32,8 @@
     "thermostat"
   ],
   "devDependencies": {
-    "@types/node": "^22",
-    "homebridge": "^1.9.0"
+    "@types/node": "^18 || ^20 || ^22 || ^24 || ^26",
+    "homebridge": "^1.6.0 || ^2.0.0"
   },
   "maintainers": [
     {


### PR DESCRIPTION
Adding Node 24.x and 26.x, Homebridge 2.0 (not the beta)