### PR TITLE
Fix NG 0002 errors, remove dup FAN_SPEED parameter

### DIFF
--- a/src/airstage/constants.js
+++ b/src/airstage/constants.js
@@ -6,11 +6,10 @@ module.exports.MANUFACTURER_FUJITSU = 'Fujitsu';
 // Parameter names
 module.exports.PARAMETER_MODEL = 'iu_model';
 module.exports.PARAMETER_FAN_SPEED = 'iu_fan_spd';
-module.exports.PARAMETER_ON_OFF = 'iu_onoff'
+module.exports.PARAMETER_ON_OFF = 'iu_onoff';
 module.exports.PARAMETER_SET_TEMPERATURE = 'iu_set_tmp';
 module.exports.PARAMETER_INDOOR_TEMPERATURE = 'iu_indoor_tmp';
 module.exports.PARAMETER_OPERATION_MODE = 'iu_op_mode';
-module.exports.PARAMETER_FAN_SPEED = 'iu_fan_spd';
 module.exports.PARAMETER_AIRFLOW_VERTICAL_DIRECTION = 'iu_af_dir_vrt';
 module.exports.PARAMETER_AIRFLOW_VERTICAL_SWING = 'iu_af_swg_vrt';
 module.exports.PARAMETER_POWERFUL = 'iu_powerful';
@@ -19,7 +18,6 @@ module.exports.PARAMETER_ENERGY_SAVING_FAN = 'iu_fan_ctrl';
 module.exports.PARAMETER_MINIMUM_HEAT = 'iu_min_heat';
 
 module.exports.PARAMETER_NAMES_BESIDES_MODEL = [
-    module.exports.PARAMETER_FAN_SPEED,
     module.exports.PARAMETER_ON_OFF,
     module.exports.PARAMETER_SET_TEMPERATURE,
     module.exports.PARAMETER_INDOOR_TEMPERATURE,

--- a/src/airstage/lan/api/constants.js
+++ b/src/airstage/lan/api/constants.js
@@ -15,15 +15,15 @@ module.exports.SET_LEVEL_GET = '03';
 module.exports.SET_LEVEL_SET = '02';
 
 // Request header keys
-module.exports.REQUEST_HEADER_CONTENT_LENGTH = 'content-length';
-module.exports.REQUEST_HEADER_USER_AGENT = 'user-agent';
+module.exports.REQUEST_HEADER_CONTENT_LENGTH = 'Content-Length';
+module.exports.REQUEST_HEADER_USER_AGENT = 'User-Agent';
 
 // Parameter results
 module.exports.PARAMETER_RESULT_SUCCESS = 'OK';
 
 // Request header templates
 module.exports.REQUEST_HEADERS_POST = {
-    'content-type': 'application/json'
+    'Content-Type': 'application/json'
 };
 
 // Result template


### PR DESCRIPTION
All local commands to the unit were erroring out silently with NG 0002. After reproducing with curl it was determined that the errors were due to case-sensivity for the header values sent in the request to the unit.

The updated header constants resolve the issue.

Also cleaned up the duplicate FAN_SPEED parameter.